### PR TITLE
Remove payment instrument from basket on error

### DIFF
--- a/adyen/utils/constants.mjs
+++ b/adyen/utils/constants.mjs
@@ -48,4 +48,4 @@ export const ORDER = Object.freeze({
     CONFIRMATION_STATUS_NOT_CONFIRMED: 'not_confirmed'
 })
 
-export const APPLICATION_VERSION = '1.0.0'
+export const APPLICATION_VERSION = '1.0.0-beta'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adyen-salesforce-pwa",
-  "version": "1.0.0",
+  "version": "1.0.0-beta",
   "license": "See license in LICENSE",
   "engines": {
     "node": "^16.0.0 || ^18.0.0",
@@ -19,6 +19,12 @@
     "husky": "^8.0.3",
     "style-loader": "^3.3.3",
     "yargs": "^17.7.2"
+  },
+  "dependencies": {
+    "@adyen/adyen-web": "^5.51.0",
+    "@adyen/api-library": "^14.3.0",
+    "express-validator": "^7.0.1",
+    "uuid": "^9.0.1"
   },
   "scripts": {
     "analyze-build": "cross-env MOBIFY_ANALYZE=true npm run build",
@@ -62,11 +68,5 @@
     "iOS >= 9.0",
     "Android >= 4.4.4",
     "last 4 ChromeAndroid versions"
-  ],
-  "dependencies": {
-    "@adyen/adyen-web": "^5.51.0",
-    "@adyen/api-library": "^14.3.0",
-    "express-validator": "^7.0.1",
-    "uuid": "^9.0.1"
-  }
+  ]
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- In case of order failure we need to remove the PIs from the basket
- What existing problem does this pull request solve?
- Provide the option to shopper to choose different PI

## Tested scenarios
- Cards
- Paypal


**Fixed issue**:  SFI-510
