### PR TITLE
Display voucher on confirmation page

### DIFF
--- a/packages/adyen-retail-react-app/build/loadable-stats.json
+++ b/packages/adyen-retail-react-app/build/loadable-stats.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "hash": "9d928fc960acffb62f28",
+  "hash": "810d43be6f8fd54ff184",
   "publicPath": "/mobify/bundle/development/",
   "outputPath": "/Users/aleksandarm/Repositories/adyen-salesforce-headless-commerce-pwa/packages/adyen-retail-react-app/build",
   "assetsByChunkName": {
@@ -54,7 +54,7 @@
     {
       "type": "asset",
       "name": "vendor.js",
-      "size": 8692676,
+      "size": 8695863,
       "emitted": false,
       "comparedForEmit": false,
       "cached": true,
@@ -81,7 +81,7 @@
     {
       "type": "asset",
       "name": "main.js",
-      "size": 1221139,
+      "size": 1221433,
       "emitted": false,
       "comparedForEmit": false,
       "cached": true,

--- a/packages/adyen-retail-react-app/build/loadable-stats.json
+++ b/packages/adyen-retail-react-app/build/loadable-stats.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "hash": "810d43be6f8fd54ff184",
+  "hash": "b8daa8086eb61531c6dc",
   "publicPath": "/mobify/bundle/development/",
   "outputPath": "/Users/aleksandarm/Repositories/adyen-salesforce-headless-commerce-pwa/packages/adyen-retail-react-app/build",
   "assetsByChunkName": {
@@ -54,7 +54,7 @@
     {
       "type": "asset",
       "name": "vendor.js",
-      "size": 8695863,
+      "size": 8696109,
       "emitted": false,
       "comparedForEmit": false,
       "cached": true,

--- a/packages/adyen-retail-react-app/overrides/app/routes.jsx
+++ b/packages/adyen-retail-react-app/overrides/app/routes.jsx
@@ -54,6 +54,9 @@ const CheckoutConfirmation = loadable(() => import('@adyen/adyen-salesforce-pwa'
                 useProducts={useProducts}
                 useAuthHelper={useAuthHelper}
                 AuthHelpers={AuthHelpers}
+                useAccessToken={useAccessToken}
+                useCustomerId={useCustomerId}
+                useCustomerType={useCustomerType}
             />
         )
     }

--- a/packages/adyen-salesforce-pwa/lib/api/controllers/payments.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/payments.js
@@ -272,11 +272,12 @@ async function sendPayments(req, res, next) {
             )
         }
 
-        const checkoutResponse = createCheckoutResponse(response)
+        const checkoutResponse = createCheckoutResponse(response, order.orderNo)
         if (checkoutResponse.isFinal && !checkoutResponse.isSuccessful) {
             throw new Error(errorMessages.PAYMENT_NOT_SUCCESSFUL)
         }
 
+        Logger.info('sendPayments', `checkoutResponse ${JSON.stringify(checkoutResponse)}`)
         res.locals.response = checkoutResponse
         next()
     } catch (err) {

--- a/packages/adyen-salesforce-pwa/lib/api/controllers/payments.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/payments.js
@@ -14,7 +14,7 @@ import AdyenCheckoutConfig from './checkout-config'
 import Logger from './logger'
 import {v4 as uuidv4} from 'uuid'
 import {OrderApiClient} from './orderApi'
-import { getAdyenConfigForCurrentSite } from "../../utils/getAdyenConfigForCurrentSite.mjs";
+import {getAdyenConfigForCurrentSite} from '../../utils/getAdyenConfigForCurrentSite.mjs'
 
 const errorMessages = {
     AMOUNT_NOT_CORRECT: 'amount not correct',

--- a/packages/adyen-salesforce-pwa/lib/api/controllers/tests/payments.test.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/tests/payments.test.js
@@ -174,7 +174,7 @@ describe('payments controller', () => {
             isSuccessful: true,
             merchantReference: 'reference123'
         })
-        expect(consoleInfoSpy).toHaveBeenCalledTimes(3)
+        expect(consoleInfoSpy).toHaveBeenCalledTimes(4)
         expect(consoleInfoSpy.mock.calls[0][0]).toContain('sendPayments start')
         expect(consoleInfoSpy.mock.calls[1][0]).toContain('sendPayments orderCreated 123')
         expect(consoleInfoSpy.mock.calls[2][0]).toContain('sendPayments resultCode Authorised')
@@ -259,7 +259,7 @@ describe('payments controller', () => {
             merchantReference: 'reference123'
         })
         expect(mockAddPaymentInstrumentToBasket).toHaveBeenCalled()
-        expect(consoleInfoSpy).toHaveBeenCalledTimes(4)
+        expect(consoleInfoSpy).toHaveBeenCalledTimes(5)
         expect(consoleInfoSpy.mock.calls[0][0]).toContain('sendPayments start')
         expect(consoleInfoSpy.mock.calls[1][0]).toContain(
             'sendPayments addPaymentInstrumentToBasket'
@@ -384,7 +384,7 @@ describe('payments controller', () => {
             isSuccessful: true,
             merchantReference: 'reference123'
         })
-        expect(consoleInfoSpy).toHaveBeenCalledTimes(3)
+        expect(consoleInfoSpy).toHaveBeenCalledTimes(4)
         expect(consoleInfoSpy.mock.calls[0][0]).toContain('sendPayments start')
         expect(consoleInfoSpy.mock.calls[1][0]).toContain('sendPayments orderCreated 123')
         expect(consoleInfoSpy.mock.calls[2][0]).toContain('sendPayments resultCode Authorised')
@@ -540,7 +540,7 @@ describe('payments controller', () => {
                 idempotencyKey: expect.any(String)
             }
         )
-        expect(consoleInfoSpy).toHaveBeenCalledTimes(3)
+        expect(consoleInfoSpy).toHaveBeenCalledTimes(4)
         expect(consoleInfoSpy.mock.calls[0][0]).toContain('sendPayments start')
         expect(consoleInfoSpy.mock.calls[1][0]).toContain('sendPayments orderCreated 123')
         expect(consoleInfoSpy.mock.calls[2][0]).toContain('sendPayments resultCode Authorised')
@@ -620,7 +620,7 @@ describe('payments controller', () => {
                 idempotencyKey: expect.any(String)
             }
         )
-        expect(consoleInfoSpy).toHaveBeenCalledTimes(3)
+        expect(consoleInfoSpy).toHaveBeenCalledTimes(4)
         expect(consoleInfoSpy.mock.calls[0][0]).toContain('sendPayments start')
         expect(consoleInfoSpy.mock.calls[1][0]).toContain('sendPayments orderCreated 123')
         expect(consoleInfoSpy.mock.calls[2][0]).toContain('sendPayments resultCode Authorised')
@@ -703,7 +703,7 @@ describe('payments controller', () => {
                 idempotencyKey: expect.any(String)
             }
         )
-        expect(consoleInfoSpy).toHaveBeenCalledTimes(3)
+        expect(consoleInfoSpy).toHaveBeenCalledTimes(4)
         expect(consoleInfoSpy.mock.calls[0][0]).toContain('sendPayments start')
         expect(consoleInfoSpy.mock.calls[1][0]).toContain('sendPayments orderCreated 123')
         expect(consoleInfoSpy.mock.calls[2][0]).toContain('sendPayments resultCode Authorised')
@@ -780,7 +780,7 @@ describe('payments controller', () => {
             merchantReference: 'reference123'
         })
         expect(mockUpdateOrderPaymentTransaction).toHaveBeenCalled()
-        expect(consoleInfoSpy).toHaveBeenCalledTimes(3)
+        expect(consoleInfoSpy).toHaveBeenCalledTimes(4)
         expect(consoleInfoSpy.mock.calls[0][0]).toContain('sendPayments start')
         expect(consoleInfoSpy.mock.calls[1][0]).toContain('sendPayments orderCreated 123')
         expect(consoleInfoSpy.mock.calls[2][0]).toContain('sendPayments resultCode Authorised')

--- a/packages/adyen-salesforce-pwa/lib/api/routes/index.js
+++ b/packages/adyen-salesforce-pwa/lib/api/routes/index.js
@@ -54,6 +54,11 @@ function registerAdyenEndpoints(app, runtime, overrides) {
         query('amazonCheckoutSessionId').optional().escape(),
         runtime.render
     )
+    app.get(
+        '*/checkout/confirmation/:orderNo',
+        query('adyenAction').optional().escape(),
+        runtime.render
+    )
     app.get('/api/adyen/environment', ...environmentHandler)
     app.get('/api/adyen/paymentMethods', ...paymentMethodsHandler)
     app.post('/api/adyen/payments/details', ...paymentsDetailsHandler)

--- a/packages/adyen-salesforce-pwa/lib/components/adyenCheckout.jsx
+++ b/packages/adyen-salesforce-pwa/lib/components/adyenCheckout.jsx
@@ -17,6 +17,7 @@ const AdyenCheckoutComponent = (props) => {
         const urlParams = new URLSearchParams(location.search)
         const redirectResult = urlParams.get('redirectResult')
         const amazonCheckoutSessionId = urlParams.get('amazonCheckoutSessionId')
+        const adyenAction = urlParams.get('adyenAction')
 
         const createCheckout = async () => {
             const paymentMethodsConfiguration = await getPaymentMethodsConfiguration(props)
@@ -56,6 +57,10 @@ const AdyenCheckoutComponent = (props) => {
                     })
                     .mount(amazonPayContainer)
                 amazonPay.submit()
+            } else if (adyenAction) {
+                const actionString = atob(adyenAction)
+                const action = JSON.parse(actionString)
+                checkout.createFromAction(action).mount(paymentContainer.current)
             } else {
                 checkout.create('dropin').mount(paymentContainer.current)
             }

--- a/packages/adyen-salesforce-pwa/lib/context/adyen-checkout-context.jsx
+++ b/packages/adyen-salesforce-pwa/lib/context/adyen-checkout-context.jsx
@@ -68,7 +68,7 @@ export const AdyenCheckoutProvider = ({
     }, [basket?.basketId])
 
     const handleAction = async (component, responses) => {
-        if (responses.paymentsResponse.isFinal) {
+        if (responses?.paymentsResponse?.action?.type === 'voucher') {
             const action = btoa(JSON.stringify(responses?.paymentsResponse?.action))
             const url = `/checkout/confirmation/${responses?.paymentsResponse?.merchantReference}?adyenAction=${action}`
             navigate(url)

--- a/packages/adyen-salesforce-pwa/lib/context/adyen-checkout-context.jsx
+++ b/packages/adyen-salesforce-pwa/lib/context/adyen-checkout-context.jsx
@@ -67,6 +67,16 @@ export const AdyenCheckoutProvider = ({
         }
     }, [basket?.basketId])
 
+    const handleAction = async (component, responses) => {
+        if (responses.paymentsResponse.isFinal) {
+            const action = btoa(JSON.stringify(responses?.paymentsResponse?.action))
+            const url = `/checkout/confirmation/${responses?.paymentsResponse?.merchantReference}?adyenAction=${action}`
+            navigate(url)
+        } else {
+            await component.handleAction(responses?.paymentsResponse?.action)
+        }
+    }
+
     const getPaymentMethodsConfiguration = async ({
         beforeSubmit = [],
         afterSubmit = [],
@@ -94,7 +104,7 @@ export const AdyenCheckoutProvider = ({
         if (responses?.paymentsResponse?.isSuccessful) {
             navigate(`/checkout/confirmation/${responses?.paymentsResponse?.merchantReference}`)
         } else if (responses?.paymentsResponse?.action) {
-            await component.handleAction(responses?.paymentsResponse?.action)
+            await handleAction(component, responses)
         } else {
             return new Error(responses?.paymentsResponse)
         }

--- a/packages/adyen-salesforce-pwa/lib/pages/checkout/confirmation.jsx
+++ b/packages/adyen-salesforce-pwa/lib/pages/checkout/confirmation.jsx
@@ -5,6 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import React, {Fragment, useEffect} from 'react'
+import {useLocation} from 'react-router-dom'
 import {FormattedMessage, FormattedNumber} from 'react-intl'
 import {
     Alert,
@@ -26,8 +27,7 @@ import {getCreditCardIcon} from '@salesforce/retail-react-app/app/utils/cc-utils
 import useNavigation from '@salesforce/retail-react-app/app/hooks/use-navigation'
 import Link from '@salesforce/retail-react-app/app/components/link'
 import AddressDisplay from '@salesforce/retail-react-app/app/components/address-display'
-import PostCheckoutRegistrationFields
-    from '@salesforce/retail-react-app/app/components/forms/post-checkout-registration-fields'
+import PostCheckoutRegistrationFields from '@salesforce/retail-react-app/app/components/forms/post-checkout-registration-fields'
 import PromoPopover from '@salesforce/retail-react-app/app/components/promo-popover'
 import ItemVariantProvider from '@salesforce/retail-react-app/app/components/item-variant'
 import CartItemVariantImage from '@salesforce/retail-react-app/app/components/item-variant/item-image'
@@ -36,13 +36,16 @@ import CartItemVariantAttributes from '@salesforce/retail-react-app/app/componen
 import CartItemVariantPrice from '@salesforce/retail-react-app/app/components/item-variant/item-price'
 import {useCurrentCustomer} from '@salesforce/retail-react-app/app/hooks/use-current-customer'
 import {API_ERROR_MESSAGE} from '@salesforce/retail-react-app/app/constants'
-import PropTypes from "prop-types";
+import PropTypes from 'prop-types'
+import AdyenCheckout from '../../components/adyenCheckout'
+import {AdyenCheckoutProvider} from '../../context/adyen-checkout-context'
 
 const onClient = typeof window !== 'undefined'
 
 const CheckoutConfirmation = ({useOrder, useProducts, useAuthHelper, AuthHelpers}) => {
     const {orderNo} = useParams()
     const navigate = useNavigation()
+    const location = useLocation()
     const {data: customer} = useCurrentCustomer()
     const register = useAuthHelper(AuthHelpers.Register)
     const {data: order} = useOrder(
@@ -97,14 +100,14 @@ const CheckoutConfirmation = ({useOrder, useProducts, useAuthHelper, AuthHelpers
             const existingAccountMessage = (
                 <Fragment>
                     <FormattedMessage
-                        defaultMessage='This email already has an account.'
-                        id='checkout_confirmation.message.already_has_account'
+                        defaultMessage="This email already has an account."
+                        id="checkout_confirmation.message.already_has_account"
                     />
                     &nbsp;
-                    <Link to='/login' color='blue.600'>
+                    <Link to="/login" color="blue.600">
                         <FormattedMessage
-                            defaultMessage='Log in here'
-                            id='checkout_confirmation.link.login'
+                            defaultMessage="Log in here"
+                            id="checkout_confirmation.link.login"
                         />
                     </Link>
                 </Fragment>
@@ -119,40 +122,40 @@ const CheckoutConfirmation = ({useOrder, useProducts, useAuthHelper, AuthHelpers
     }
 
     return (
-        <Box background='gray.50'>
+        <Box background="gray.50">
             <Container
-                maxWidth='container.md'
+                maxWidth="container.md"
                 py={{base: 7, md: 16}}
                 px={{base: 0, md: 4}}
-                data-testid='sf-checkout-confirmation-container'
+                data-testid="sf-checkout-confirmation-container"
             >
                 <Stack spacing={4}>
-                    <Box layerStyle='card' rounded={[0, 0, 'base']} px={[4, 4, 6]} py={[6, 6, 8]}>
+                    <Box layerStyle="card" rounded={[0, 0, 'base']} px={[4, 4, 6]} py={[6, 6, 8]}>
                         <Stack spacing={6}>
-                            <Heading align='center' fontSize={['2xl']}>
+                            <Heading align="center" fontSize={['2xl']}>
                                 <FormattedMessage
-                                    defaultMessage='Thank you for your order!'
-                                    id='checkout_confirmation.heading.thank_you_for_order'
+                                    defaultMessage="Thank you for your order!"
+                                    id="checkout_confirmation.heading.thank_you_for_order"
                                 />
                             </Heading>
 
                             <Box>
-                                <Container variant='form'>
+                                <Container variant="form">
                                     <Stack spacing={3}>
-                                        <Text align='center'>
+                                        <Text align="center">
                                             <FormattedMessage
-                                                defaultMessage='Order Number'
-                                                id='checkout_confirmation.label.order_number'
+                                                defaultMessage="Order Number"
+                                                id="checkout_confirmation.label.order_number"
                                             />
                                             :{' '}
-                                            <Text as='span' fontWeight='bold'>
+                                            <Text as="span" fontWeight="bold">
                                                 {order.orderNo}
                                             </Text>
                                         </Text>
-                                        <Text align='center'>
+                                        <Text align="center">
                                             <FormattedMessage
-                                                defaultMessage='We will send an email to <b>{email}</b> with your confirmation number and receipt shortly.'
-                                                id='checkout_confirmation.message.will_email_shortly'
+                                                defaultMessage="We will send an email to <b>{email}</b> with your confirmation number and receipt shortly."
+                                                id="checkout_confirmation.message.will_email_shortly"
                                                 values={{
                                                     b: (chunks) => <b>{chunks}</b>,
                                                     email: order.customerInfo.email
@@ -162,10 +165,16 @@ const CheckoutConfirmation = ({useOrder, useProducts, useAuthHelper, AuthHelpers
 
                                         <Spacer />
 
-                                        <Button as={Link} href='/' variant='outline'>
+                                        {location?.search?.includes('adyenAction') && (
+                                            <AdyenCheckout />
+                                        )}
+
+                                        <Spacer />
+
+                                        <Button as={Link} href="/" variant="outline">
                                             <FormattedMessage
-                                                defaultMessage='Continue Shopping'
-                                                id='checkout_confirmation.link.continue_shopping'
+                                                defaultMessage="Continue Shopping"
+                                                id="checkout_confirmation.link.continue_shopping"
                                             />
                                         </Button>
                                     </Stack>
@@ -176,23 +185,23 @@ const CheckoutConfirmation = ({useOrder, useProducts, useAuthHelper, AuthHelpers
 
                     {customer.isGuest && (
                         <Box
-                            layerStyle='card'
+                            layerStyle="card"
                             rounded={[0, 0, 'base']}
                             px={[4, 4, 6]}
                             py={[6, 6, 8]}
                         >
-                            <Container variant='form'>
-                                <Heading fontSize='lg' marginBottom={6}>
+                            <Container variant="form">
+                                <Heading fontSize="lg" marginBottom={6}>
                                     <FormattedMessage
-                                        defaultMessage='Create an account for faster checkout'
-                                        id='checkout_confirmation.heading.create_account'
+                                        defaultMessage="Create an account for faster checkout"
+                                        id="checkout_confirmation.heading.create_account"
                                     />
                                 </Heading>
 
                                 <form onSubmit={form.handleSubmit(submitForm)}>
                                     <Stack spacing={4}>
                                         {form.formState.errors?.global && (
-                                            <Alert status='error'>
+                                            <Alert status="error">
                                                 <AlertIcon />
                                                 {form.formState.errors.global.message}
                                             </Alert>
@@ -201,14 +210,14 @@ const CheckoutConfirmation = ({useOrder, useProducts, useAuthHelper, AuthHelpers
                                         <PostCheckoutRegistrationFields form={form} />
 
                                         <Button
-                                            type='submit'
-                                            width='full'
+                                            type="submit"
+                                            width="full"
                                             onClick={() => form.clearErrors('global')}
                                             isLoading={form.formState.isSubmitting}
                                         >
                                             <FormattedMessage
-                                                defaultMessage='Create Account'
-                                                id='checkout_confirmation.button.create_account'
+                                                defaultMessage="Create Account"
+                                                id="checkout_confirmation.button.create_account"
                                             />
                                         </Button>
                                     </Stack>
@@ -217,22 +226,22 @@ const CheckoutConfirmation = ({useOrder, useProducts, useAuthHelper, AuthHelpers
                         </Box>
                     )}
 
-                    <Box layerStyle='card' rounded={[0, 0, 'base']} px={[4, 4, 6]} py={[6, 6, 8]}>
-                        <Container variant='form'>
+                    <Box layerStyle="card" rounded={[0, 0, 'base']} px={[4, 4, 6]} py={[6, 6, 8]}>
+                        <Container variant="form">
                             <Stack spacing={6}>
-                                <Heading fontSize='lg'>
+                                <Heading fontSize="lg">
                                     <FormattedMessage
-                                        defaultMessage='Delivery Details'
-                                        id='checkout_confirmation.heading.delivery_details'
+                                        defaultMessage="Delivery Details"
+                                        id="checkout_confirmation.heading.delivery_details"
                                     />
                                 </Heading>
 
                                 <SimpleGrid columns={[1, 1, 2]} spacing={6}>
                                     <Stack spacing={1}>
-                                        <Heading as='h3' fontSize='sm'>
+                                        <Heading as="h3" fontSize="sm">
                                             <FormattedMessage
-                                                defaultMessage='Shipping Address'
-                                                id='checkout_confirmation.heading.shipping_address'
+                                                defaultMessage="Shipping Address"
+                                                id="checkout_confirmation.heading.shipping_address"
                                             />
                                         </Heading>
                                         <AddressDisplay
@@ -241,10 +250,10 @@ const CheckoutConfirmation = ({useOrder, useProducts, useAuthHelper, AuthHelpers
                                     </Stack>
 
                                     <Stack spacing={1}>
-                                        <Heading as='h3' fontSize='sm'>
+                                        <Heading as="h3" fontSize="sm">
                                             <FormattedMessage
-                                                defaultMessage='Shipping Method'
-                                                id='checkout_confirmation.heading.shipping_method'
+                                                defaultMessage="Shipping Method"
+                                                id="checkout_confirmation.heading.shipping_method"
                                             />
                                         </Heading>
                                         <Box>
@@ -259,36 +268,36 @@ const CheckoutConfirmation = ({useOrder, useProducts, useAuthHelper, AuthHelpers
                         </Container>
                     </Box>
 
-                    <Box layerStyle='card' rounded={[0, 0, 'base']} px={[4, 4, 6]} py={[6, 6, 8]}>
-                        <Container variant='form'>
+                    <Box layerStyle="card" rounded={[0, 0, 'base']} px={[4, 4, 6]} py={[6, 6, 8]}>
+                        <Container variant="form">
                             <Stack spacing={6}>
-                                <Heading fontSize='lg'>
+                                <Heading fontSize="lg">
                                     <FormattedMessage
-                                        defaultMessage='Order Summary'
-                                        id='checkout_confirmation.heading.order_summary'
+                                        defaultMessage="Order Summary"
+                                        id="checkout_confirmation.heading.order_summary"
                                     />
                                 </Heading>
 
                                 <Stack spacing={4}>
                                     <Text>
                                         <FormattedMessage
-                                            description='# item(s) in order'
-                                            defaultMessage='{itemCount, plural, =0 {0 items} one {# item} other {# items}}'
+                                            description="# item(s) in order"
+                                            defaultMessage="{itemCount, plural, =0 {0 items} one {# item} other {# items}}"
                                             values={{
                                                 itemCount: order.productItems.reduce(
                                                     (a, b) => a + b.quantity,
                                                     0
                                                 )
                                             }}
-                                            id='checkout_confirmation.message.num_of_items_in_order'
+                                            id="checkout_confirmation.message.num_of_items_in_order"
                                         />
                                     </Text>
 
-                                    <Stack spacing={5} align='flex-start'>
+                                    <Stack spacing={5} align="flex-start">
                                         <Stack
                                             spacing={5}
-                                            align='flex-start'
-                                            width='full'
+                                            align="flex-start"
+                                            width="full"
                                             divider={<Divider />}
                                         >
                                             {order.productItems?.map((product, idx) => {
@@ -306,21 +315,21 @@ const CheckoutConfirmation = ({useOrder, useProducts, useAuthHelper, AuthHelpers
                                                         index={idx}
                                                         variant={variant}
                                                     >
-                                                        <Flex width='full' alignItems='flex-start'>
+                                                        <Flex width="full" alignItems="flex-start">
                                                             <CartItemVariantImage
-                                                                width='80px'
+                                                                width="80px"
                                                                 mr={2}
                                                             />
                                                             <Stack
                                                                 spacing={1}
-                                                                marginTop='-3px'
+                                                                marginTop="-3px"
                                                                 flex={1}
                                                             >
                                                                 <CartItemVariantName />
                                                                 <Flex
-                                                                    width='full'
-                                                                    justifyContent='space-between'
-                                                                    alignItems='flex-end'
+                                                                    width="full"
+                                                                    justifyContent="space-between"
+                                                                    alignItems="flex-end"
                                                                 >
                                                                     <CartItemVariantAttributes
                                                                         includeQuantity
@@ -334,17 +343,17 @@ const CheckoutConfirmation = ({useOrder, useProducts, useAuthHelper, AuthHelpers
                                             })}
                                         </Stack>
 
-                                        <Stack w='full' py={4} borderY='1px' borderColor='gray.200'>
-                                            <Flex justify='space-between'>
-                                                <Text fontWeight='bold'>
+                                        <Stack w="full" py={4} borderY="1px" borderColor="gray.200">
+                                            <Flex justify="space-between">
+                                                <Text fontWeight="bold">
                                                     <FormattedMessage
-                                                        defaultMessage='Subtotal'
-                                                        id='checkout_confirmation.label.subtotal'
+                                                        defaultMessage="Subtotal"
+                                                        id="checkout_confirmation.label.subtotal"
                                                     />
                                                 </Text>
-                                                <Text fontWeight='bold'>
+                                                <Text fontWeight="bold">
                                                     <FormattedNumber
-                                                        style='currency'
+                                                        style="currency"
                                                         currency={order?.currency}
                                                         value={order?.productSubTotal}
                                                     />
@@ -352,33 +361,33 @@ const CheckoutConfirmation = ({useOrder, useProducts, useAuthHelper, AuthHelpers
                                             </Flex>
                                             {order.orderPriceAdjustments?.map((adjustment) => (
                                                 <Flex
-                                                    justify='space-between'
+                                                    justify="space-between"
                                                     key={adjustment.priceAdjustmentId}
                                                 >
                                                     <Text>{adjustment.itemText}</Text>
-                                                    <Text color='green.500'>
+                                                    <Text color="green.500">
                                                         <FormattedNumber
-                                                            style='currency'
+                                                            style="currency"
                                                             currency={order?.currency}
                                                             value={adjustment.price}
                                                         />
                                                     </Text>
                                                 </Flex>
                                             ))}
-                                            <Flex justify='space-between'>
-                                                <Flex alignItems='center'>
+                                            <Flex justify="space-between">
+                                                <Flex alignItems="center">
                                                     <Text lineHeight={1}>
                                                         <FormattedMessage
-                                                            defaultMessage='Shipping'
-                                                            id='checkout_confirmation.label.shipping'
+                                                            defaultMessage="Shipping"
+                                                            id="checkout_confirmation.label.shipping"
                                                         />
                                                         {order.shippingItems[0].priceAdjustments
                                                             ?.length > 0 && (
-                                                            <Text as='span' ml={1}>
+                                                            <Text as="span" ml={1}>
                                                                 (
                                                                 <FormattedMessage
-                                                                    defaultMessage='Promotion applied'
-                                                                    id='checkout_confirmation.label.promo_applied'
+                                                                    defaultMessage="Promotion applied"
+                                                                    id="checkout_confirmation.label.promo_applied"
                                                                 />
                                                                 )
                                                             </Text>
@@ -394,7 +403,7 @@ const CheckoutConfirmation = ({useOrder, useProducts, useAuthHelper, AuthHelpers
                                                                             key={
                                                                                 adjustment.priceAdjustmentId
                                                                             }
-                                                                            fontSize='sm'
+                                                                            fontSize="sm"
                                                                         >
                                                                             {adjustment.itemText}
                                                                         </Text>
@@ -410,52 +419,52 @@ const CheckoutConfirmation = ({useOrder, useProducts, useAuthHelper, AuthHelpers
                                                         appliedDiscount?.type === 'free'
                                                 ) ? (
                                                     <Text
-                                                        as='span'
-                                                        color='green.500'
-                                                        textTransform='uppercase'
+                                                        as="span"
+                                                        color="green.500"
+                                                        textTransform="uppercase"
                                                     >
                                                         <FormattedMessage
-                                                            defaultMessage='Free'
-                                                            id='checkout_confirmation.label.free'
+                                                            defaultMessage="Free"
+                                                            id="checkout_confirmation.label.free"
                                                         />
                                                     </Text>
                                                 ) : (
                                                     <Text>
                                                         <FormattedNumber
                                                             value={order.shippingTotal}
-                                                            style='currency'
+                                                            style="currency"
                                                             currency={order.currency}
                                                         />
                                                     </Text>
                                                 )}
                                             </Flex>
-                                            <Flex justify='space-between'>
+                                            <Flex justify="space-between">
                                                 <Text>
                                                     <FormattedMessage
-                                                        defaultMessage='Tax'
-                                                        id='checkout_confirmation.label.tax'
+                                                        defaultMessage="Tax"
+                                                        id="checkout_confirmation.label.tax"
                                                     />
                                                 </Text>
                                                 <Text>
                                                     <FormattedNumber
                                                         value={order.taxTotal}
-                                                        style='currency'
+                                                        style="currency"
                                                         currency={order.currency}
                                                     />
                                                 </Text>
                                             </Flex>
                                         </Stack>
 
-                                        <Flex w='full' justify='space-between'>
-                                            <Text fontWeight='bold'>
+                                        <Flex w="full" justify="space-between">
+                                            <Text fontWeight="bold">
                                                 <FormattedMessage
-                                                    defaultMessage='Order Total'
-                                                    id='checkout_confirmation.label.order_total'
+                                                    defaultMessage="Order Total"
+                                                    id="checkout_confirmation.label.order_total"
                                                 />
                                             </Text>
-                                            <Text fontWeight='bold'>
+                                            <Text fontWeight="bold">
                                                 <FormattedNumber
-                                                    style='currency'
+                                                    style="currency"
                                                     currency={order?.currency}
                                                     value={order?.orderTotal}
                                                 />
@@ -467,37 +476,37 @@ const CheckoutConfirmation = ({useOrder, useProducts, useAuthHelper, AuthHelpers
                         </Container>
                     </Box>
 
-                    <Box layerStyle='card' rounded={[0, 0, 'base']} px={[4, 4, 6]} py={[6, 6, 8]}>
-                        <Container variant='form'>
+                    <Box layerStyle="card" rounded={[0, 0, 'base']} px={[4, 4, 6]} py={[6, 6, 8]}>
+                        <Container variant="form">
                             <Stack spacing={6}>
-                                <Heading fontSize='lg'>
+                                <Heading fontSize="lg">
                                     <FormattedMessage
-                                        defaultMessage='Payment Details'
-                                        id='checkout_confirmation.heading.payment_details'
+                                        defaultMessage="Payment Details"
+                                        id="checkout_confirmation.heading.payment_details"
                                     />
                                 </Heading>
 
                                 <SimpleGrid columns={[1, 1, 2]} spacing={6}>
                                     <Stack spacing={1}>
-                                        <Heading as='h3' fontSize='sm'>
+                                        <Heading as="h3" fontSize="sm">
                                             <FormattedMessage
-                                                defaultMessage='Billing Address'
-                                                id='checkout_confirmation.heading.billing_address'
+                                                defaultMessage="Billing Address"
+                                                id="checkout_confirmation.heading.billing_address"
                                             />
                                         </Heading>
                                         <AddressDisplay address={order.billingAddress} />
                                     </Stack>
 
                                     <Stack spacing={1}>
-                                        <Heading as='h3' fontSize='sm'>
+                                        <Heading as="h3" fontSize="sm">
                                             <FormattedMessage
-                                                defaultMessage='Payment Method'
-                                                id='checkout_confirmation.heading.payment_method'
+                                                defaultMessage="Payment Method"
+                                                id="checkout_confirmation.heading.payment_method"
                                             />
                                         </Heading>
 
-                                        <Stack direction='row'>
-                                            {CardIcon && <CardIcon layerStyle='ccIcon' />}
+                                        <Stack direction="row">
+                                            {CardIcon && <CardIcon layerStyle="ccIcon" />}
 
                                             <Box>
                                                 <Text>
@@ -518,6 +527,32 @@ const CheckoutConfirmation = ({useOrder, useProducts, useAuthHelper, AuthHelpers
         </Box>
     )
 }
+
+const CheckoutConfirmationContainer = ({
+    useAccessToken,
+    useCustomerId,
+    useCustomerType,
+    useOrder,
+    useProducts,
+    useAuthHelper,
+    AuthHelpers
+}) => {
+    return (
+        <AdyenCheckoutProvider
+            useAccessToken={useAccessToken}
+            useCustomerId={useCustomerId}
+            useCustomerType={useCustomerType}
+        >
+            <CheckoutConfirmation
+                useOrder={useOrder}
+                useProducts={useProducts}
+                useAuthHelper={useAuthHelper}
+                AuthHelpers={AuthHelpers}
+            />
+        </AdyenCheckoutProvider>
+    )
+}
+
 CheckoutConfirmation.propTypes = {
     useOrder: PropTypes.any,
     useProducts: PropTypes.any,
@@ -525,4 +560,14 @@ CheckoutConfirmation.propTypes = {
     AuthHelpers: PropTypes.any
 }
 
-export default CheckoutConfirmation
+CheckoutConfirmationContainer.propTypes = {
+    useOrder: PropTypes.any,
+    useProducts: PropTypes.any,
+    useAuthHelper: PropTypes.any,
+    AuthHelpers: PropTypes.any,
+    useAccessToken: PropTypes.any,
+    useCustomerId: PropTypes.any,
+    useCustomerType: PropTypes.any
+}
+
+export default CheckoutConfirmationContainer

--- a/packages/adyen-salesforce-pwa/lib/pages/checkout/index.jsx
+++ b/packages/adyen-salesforce-pwa/lib/pages/checkout/index.jsx
@@ -7,7 +7,10 @@
 import React, {useEffect, useState} from 'react'
 import {useLocation} from 'react-router-dom'
 import {Alert, AlertIcon, Box, Container, Grid, GridItem, Stack} from '@chakra-ui/react'
-import {CheckoutProvider, useCheckout} from '@salesforce/retail-react-app/app/pages/checkout/util/checkout-context'
+import {
+    CheckoutProvider,
+    useCheckout
+} from '@salesforce/retail-react-app/app/pages/checkout/util/checkout-context'
 import ContactInfo from '@salesforce/retail-react-app/app/pages/checkout/partials/contact-info'
 import ShippingAddress from '@salesforce/retail-react-app/app/pages/checkout/partials/shipping-address'
 import ShippingOptions from '@salesforce/retail-react-app/app/pages/checkout/partials/shipping-options'

--- a/packages/adyen-salesforce-pwa/lib/utils/createCheckoutResponse.mjs
+++ b/packages/adyen-salesforce-pwa/lib/utils/createCheckoutResponse.mjs
@@ -1,6 +1,6 @@
 import { RESULT_CODES } from "./constants.mjs";
 
-export function createCheckoutResponse(response) {
+export function createCheckoutResponse(response, orderNumber) {
   if (
     [
       RESULT_CODES.AUTHORISED,
@@ -14,7 +14,7 @@ export function createCheckoutResponse(response) {
       isFinal: true,
       isSuccessful:
         response.resultCode === RESULT_CODES.AUTHORISED || response.resultCode === RESULT_CODES.RECEIVED,
-      merchantReference: response.merchantReference,
+      merchantReference: response.merchantReference || orderNumber,
     };
   }
 
@@ -24,19 +24,13 @@ export function createCheckoutResponse(response) {
       RESULT_CODES.IDENTIFYSHOPPER,
       RESULT_CODES.CHALLENGESHOPPER,
       RESULT_CODES.PENDING,
+      RESULT_CODES.PRESENTTOSHOPPER
     ].includes(response.resultCode)
   ) {
     return {
       isFinal: false,
       action: response.action,
-    };
-  }
-
-  if (response.resultCode === RESULT_CODES.PRESENTTOSHOPPER) {
-    return {
-      isFinal: true,
-      action: response.action,
-      merchantReference: response.merchantReference,
+      merchantReference: response.merchantReference || orderNumber,
     };
   }
 

--- a/packages/adyen-salesforce-pwa/lib/utils/createCheckoutResponse.mjs
+++ b/packages/adyen-salesforce-pwa/lib/utils/createCheckoutResponse.mjs
@@ -23,13 +23,20 @@ export function createCheckoutResponse(response) {
       RESULT_CODES.REDIRECTSHOPPER,
       RESULT_CODES.IDENTIFYSHOPPER,
       RESULT_CODES.CHALLENGESHOPPER,
-      RESULT_CODES.PRESENTTOSHOPPER,
       RESULT_CODES.PENDING,
     ].includes(response.resultCode)
   ) {
     return {
       isFinal: false,
       action: response.action,
+    };
+  }
+
+  if (response.resultCode === RESULT_CODES.PRESENTTOSHOPPER) {
+    return {
+      isFinal: true,
+      action: response.action,
+      merchantReference: response.merchantReference,
     };
   }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- Instead of rendering on the checkout we present the action on confirmation page
- What existing problem does this pull request solve?
- The shopper will experience successful flow

## Tested scenarios
Description of tested scenarios:
- Payment using Boleto Bancario
<img width="1507" alt="image" src="https://github.com/Adyen/adyen-salesforce-headless-commerce-pwa/assets/6888241/ea1c858e-5e70-40c6-ab67-3a869178d5a2">

**Fixed issue**: SFI-481
