### PR TITLE
Blocked payment methods

### DIFF
--- a/packages/adyen-salesforce-pwa/lib/api/controllers/tests/payment-methods.test.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/tests/payment-methods.test.js
@@ -47,6 +47,7 @@ jest.mock('../checkout-config', () => {
 })
 describe('payment methods controller', () => {
     let req, res, next, consoleInfoSpy, consoleErrorSpy
+    let blockedPaymentMethods = ['giftcard', 'wechatpayMiniProgram', 'wechatpayQR', 'wechatpaySDK']
 
     beforeEach(() => {
         req = {
@@ -99,7 +100,7 @@ describe('payment methods controller', () => {
         expect(mockPaymentMethods).toHaveBeenCalledWith(
             {
                 amount: {currency: 'USD', value: 10000},
-                blockedPaymentMethods: ['giftcard'],
+                blockedPaymentMethods,
                 countryCode: 'US',
                 merchantAccount: 'mock_ADYEN_MERCHANT_ACCOUNT',
                 shopperLocale: 'en-US',
@@ -153,7 +154,7 @@ describe('payment methods controller', () => {
         expect(mockPaymentMethods).toHaveBeenCalledWith(
             {
                 amount: {currency: 'USD', value: 10000},
-                blockedPaymentMethods: ['giftcard'],
+                blockedPaymentMethods,
                 countryCode: 'US',
                 merchantAccount: 'mock_ADYEN_MERCHANT_ACCOUNT',
                 shopperLocale: 'en-US',
@@ -223,7 +224,7 @@ describe('payment methods controller', () => {
         await PaymentMethodsController(req, res, next)
         expect(mockPaymentMethods).toHaveBeenCalledWith(
             {
-                blockedPaymentMethods: ['giftcard'],
+                blockedPaymentMethods,
                 countryCode: 'US',
                 merchantAccount: 'mock_ADYEN_MERCHANT_ACCOUNT',
                 shopperLocale: 'en-US',

--- a/packages/adyen-salesforce-pwa/lib/utils/constants.mjs
+++ b/packages/adyen-salesforce-pwa/lib/utils/constants.mjs
@@ -4,7 +4,10 @@ export const PAYMENT_METHODS = {
 }
 
 export const PAYMENT_METHOD_TYPES = {
-    GIFT_CARD: 'giftcard'
+    GIFT_CARD: 'giftcard',
+    WECHATPAY_MINI_PROGRAM: 'wechatpayMiniProgram',
+    WECHATPAY_QR: 'wechatpayQR',
+    WECHATPAY_SDK: 'wechatpaySDK'
 }
 
 export const RESULT_CODES = {
@@ -20,7 +23,12 @@ export const RESULT_CODES = {
     REFUSED: 'Refused',
 }
 
-export const BLOCKED_PAYMENT_METHODS = [PAYMENT_METHOD_TYPES.GIFT_CARD]
+export const BLOCKED_PAYMENT_METHODS = [
+    PAYMENT_METHOD_TYPES.GIFT_CARD,
+    PAYMENT_METHOD_TYPES.WECHATPAY_MINI_PROGRAM,
+    PAYMENT_METHOD_TYPES.WECHATPAY_QR,
+    PAYMENT_METHOD_TYPES.WECHATPAY_SDK
+]
 
 export const SHOPPER_INTERACTIONS = {
     CONT_AUTH: 'ContAuth',


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- Show wechatpay web variant only
- What existing problem does this pull request solve?
- showing all wechatpay options are not needed for the web checkout

## Tested scenarios
Description of tested scenarios:
- Wechatpay

