### PR TITLE
Recreate basket after payments fail

### DIFF
--- a/packages/adyen-salesforce-pwa/lib/api/controllers/orderApi.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/orderApi.js
@@ -55,13 +55,11 @@ export class OrderApiClient {
     }
 
     async updateOrderStatus(orderNo, status) {
-        Logger.error('updateOrderStatus');
         const response = await this.base('PUT', `${orderNo}/status`, {
             body: JSON.stringify({status: status})
         })
         if (!response.ok) {
             const error = await response.text()
-            Logger.error(error);
             throw new Error(`${response.status} ${response.statusText}`, {
                 cause: error
             })

--- a/packages/adyen-salesforce-pwa/lib/api/controllers/orderApi.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/orderApi.js
@@ -55,11 +55,13 @@ export class OrderApiClient {
     }
 
     async updateOrderStatus(orderNo, status) {
+        Logger.error('updateOrderStatus');
         const response = await this.base('PUT', `${orderNo}/status`, {
             body: JSON.stringify({status: status})
         })
         if (!response.ok) {
             const error = await response.text()
+            Logger.error(error);
             throw new Error(`${response.status} ${response.statusText}`, {
                 cause: error
             })

--- a/packages/adyen-salesforce-pwa/lib/api/controllers/payments.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/payments.js
@@ -225,6 +225,8 @@ async function sendPayments(req, res, next) {
     }
 
     let order
+    let initialBasket;
+
     try {
         const {data} = req.body
         const {siteId} = req.query
@@ -238,17 +240,17 @@ async function sendPayments(req, res, next) {
             headers: {authorization: req.headers.authorization}
         })
 
-        const basket = await shopperBaskets.getBasket({
+        initialBasket = await shopperBaskets.getBasket({
             parameters: {
                 basketId: req.headers.basketid
             }
         })
 
-        if (!basket) {
+        if (!initialBasket) {
             throw new AdyenError(errorMessages.INVALID_BASKET, 404)
         }
 
-        if (!basket?.paymentInstruments || !basket?.paymentInstruments?.length) {
+        if (!initialBasket?.paymentInstruments || !initialBasket?.paymentInstruments?.length) {
             Logger.info('sendPayments', 'addPaymentInstrumentToBasket')
             const isCardPayment = data?.paymentMethod?.type === 'scheme';
             const paymentMethodId = isCardPayment
@@ -256,7 +258,7 @@ async function sendPayments(req, res, next) {
               : PAYMENT_METHODS.ADYEN_COMPONENT;
             const paymentInstrumentReq = {
                 body: {
-                    amount: basket.orderTotal,
+                    amount: initialBasket.orderTotal,
                     paymentMethodId,
                     paymentCard: {
                         cardType: isCardPayment
@@ -362,11 +364,16 @@ async function sendPayments(req, res, next) {
             }
         })
         if (basket?.paymentInstruments?.length) {
+            Logger.info('removeAllPaymentInstrumentsFromBasket');
             await removeAllPaymentInstrumentsFromBasket(basket, shopperBaskets)
         }
         if (order?.orderNo) {
+            Logger.info('updateOrderStatus');
             const orderApi = new OrderApiClient()
             await orderApi.updateOrderStatus(order.orderNo, ORDER.ORDER_STATUS_FAILED)
+            await shopperBaskets.createBasket({
+                body: initialBasket,
+            })
         }
         next(err)
     }

--- a/packages/adyen-salesforce-pwa/lib/api/controllers/payments.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/payments.js
@@ -368,7 +368,7 @@ async function sendPayments(req, res, next) {
             await removeAllPaymentInstrumentsFromBasket(basket, shopperBaskets)
         }
         if (order?.orderNo) {
-            Logger.info('updateOrderStatus');
+            Logger.info('updateOrderStatus and recreate basket');
             const orderApi = new OrderApiClient()
             await orderApi.updateOrderStatus(order.orderNo, ORDER.ORDER_STATUS_FAILED)
             await shopperBaskets.createBasket({

--- a/packages/adyen-salesforce-pwa/lib/api/controllers/tests/payments.test.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/tests/payments.test.js
@@ -4,6 +4,7 @@ import {AdyenError} from '../../models/AdyenError'
 
 let mockPayments = jest.fn()
 let mockGetBasket = jest.fn()
+let mockCreateBasket = jest.fn()
 let mockAddPaymentInstrumentToBasket = jest.fn()
 let mockRemovePaymentInstrumentFromBasket = jest.fn()
 let mockCreateOrder = jest.fn()
@@ -35,6 +36,7 @@ jest.mock('commerce-sdk-isomorphic', () => {
     return {
         ShopperBaskets: jest.fn().mockImplementation(() => {
             return {
+                createBasket: mockCreateBasket,
                 getBasket: mockGetBasket,
                 addPaymentInstrumentToBasket: mockAddPaymentInstrumentToBasket,
                 removePaymentInstrumentFromBasket: mockRemovePaymentInstrumentFromBasket
@@ -372,7 +374,7 @@ describe('payments controller', () => {
         await PaymentsController(req, res, next)
         expect(res.locals.response).toBeNil()
         expect(mockUpdateOrderStatus).toHaveBeenCalled()
-        expect(consoleInfoSpy).toHaveBeenCalledTimes(2)
+        expect(consoleInfoSpy).toHaveBeenCalledTimes(3)
         expect(consoleInfoSpy.mock.calls[0][0]).toContain('sendPayments start')
         expect(consoleInfoSpy.mock.calls[1][0]).toContain('sendPayments orderCreated 123')
         expect(consoleErrorSpy).toHaveBeenCalled()
@@ -999,7 +1001,7 @@ describe('payments controller', () => {
 
         await PaymentsController(req, res, next)
         expect(res.locals.response).toBeNil()
-        expect(consoleInfoSpy).toHaveBeenCalledTimes(3)
+        expect(consoleInfoSpy).toHaveBeenCalledTimes(4)
         expect(consoleInfoSpy.mock.calls[0][0]).toContain('sendPayments start')
         expect(consoleInfoSpy.mock.calls[1][0]).toContain('sendPayments orderCreated 123')
         expect(consoleInfoSpy.mock.calls[2][0]).toContain('sendPayments resultCode Error')
@@ -1090,7 +1092,7 @@ describe('payments controller', () => {
         await PaymentsController(req, res, next)
         expect(res.locals.response).toBeNil()
         expect(mockRemovePaymentInstrumentFromBasket).toHaveBeenCalled()
-        expect(consoleInfoSpy).toHaveBeenCalledTimes(3)
+        expect(consoleInfoSpy).toHaveBeenCalledTimes(5)
         expect(consoleInfoSpy.mock.calls[0][0]).toContain('sendPayments start')
         expect(consoleInfoSpy.mock.calls[1][0]).toContain('sendPayments orderCreated 123')
         expect(consoleInfoSpy.mock.calls[2][0]).toContain('sendPayments resultCode Error')

--- a/packages/adyen-salesforce-pwa/lib/components/helpers/baseConfig.js
+++ b/packages/adyen-salesforce-pwa/lib/components/helpers/baseConfig.js
@@ -9,7 +9,7 @@ export const baseConfig = ({
     beforeAdditionalDetails = [],
     afterAdditionalDetails = [],
     onError = () => {
-        props.onNavigate('/checkout/error')
+        window.location.reload()
     },
     ...props
 }) => {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
Being able to redo a payment
- What existing problem does this pull request solve?
Option for shopper to retry a payment

## Tested scenarios
Description of tested scenarios:
- Failed payment and new basket created

**Fixed issue**:  SFI-1048
