### PR TITLE
feat: add optional temporary basket deletion on express payment cancellation

### DIFF
--- a/packages/adyen-salesforce-pwa/lib/api/controllers/payment-cancel-express.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/payment-cancel-express.js
@@ -1,11 +1,15 @@
 import Logger from '../models/logger'
 import {revertCheckoutStateForExpress} from '../helpers/paymentsHelper.js'
+import {deleteTemporaryBasket} from '../helpers/basketHelper.js'
 
 /**
  * An Express middleware that handles the cancellation of an express payment.
  * It cleans up the basket, removes shipping method and shipping address.
+ * Optionally deletes the temporary basket if requested.
  *
  * @param {object} req - The Express request object.
+ * @param {object} req.body - The request body.
+ * @param {boolean} [req.body.deleteTempBasket] - Optional flag to delete temporary basket.
  * @param {object} res - The Express response object (not used).
  * @param {Function} next - The Express next middleware function.
  * @returns {Promise<void>}
@@ -14,8 +18,14 @@ async function paymentCancelExpress(req, res, next) {
     Logger.info('paymentCancelExpress', 'start')
     try {
         const {adyen: adyenContext} = res.locals
+        const {deleteTempBasket = false} = req.body || {}
 
-        await revertCheckoutStateForExpress(adyenContext, 'paymentCancelExpress')
+        if (deleteTempBasket) {
+            await deleteTemporaryBasket(adyenContext.authorization, adyenContext.basket)
+        } else {
+            await revertCheckoutStateForExpress(adyenContext, 'paymentCancelExpress')
+        }
+
         res.locals.response = {}
         next()
     } catch (err) {

--- a/packages/adyen-salesforce-pwa/lib/api/helpers/basketHelper.js
+++ b/packages/adyen-salesforce-pwa/lib/api/helpers/basketHelper.js
@@ -67,6 +67,28 @@ export async function getCurrentBasketForAuthorizedShopper(authorization, custom
 }
 
 /**
+ * Deletes a temporary basket.
+ * @param {string} authorization - The shopper's authorization token.
+ * @param {object} basket - The basket object from adyen context.
+ * @returns {Promise<void>}
+ * @throws {AdyenError} If the basket is not temporary or deletion fails.
+ */
+export async function deleteTemporaryBasket(authorization, basket) {
+    if (!basket) {
+        throw new AdyenError(ERROR_MESSAGE.INVALID_BASKET, 404)
+    }
+
+    if (basket.temporaryBasket !== true) {
+        throw new AdyenError('Cannot delete non-temporary basket', 400)
+    }
+
+    const shopperBaskets = createShopperBasketsClient(authorization)
+    await shopperBaskets.deleteBasket({
+        parameters: {basketId: basket.basketId}
+    })
+}
+
+/**
  * Removes any existing temporary baskets for the current customer.
  */
 export async function removeExistingTemporaryBaskets(authorization, customerId) {

--- a/packages/adyen-salesforce-pwa/lib/components/helpers/applePayExpress.utils.js
+++ b/packages/adyen-salesforce-pwa/lib/components/helpers/applePayExpress.utils.js
@@ -298,6 +298,10 @@ export const onErrorHandler = async (error, component, props) => {
             deleteTempBasket: isTemporaryBasket
         })
 
+        if (!isTemporaryBasket) {
+            props.navigate(`/checkout?error=true`)
+        }
+
         return {cancelled: true, basketDeleted: isTemporaryBasket}
     } catch (err) {
         console.error('Error during express payment cancellation:', err)

--- a/packages/adyen-salesforce-pwa/lib/components/helpers/applePayExpress.utils.js
+++ b/packages/adyen-salesforce-pwa/lib/components/helpers/applePayExpress.utils.js
@@ -78,6 +78,7 @@ export const getAppleButtonConfig = (props = {}) => {
     const propsWithGetBasket = {...props, getBasket, setBasket}
 
     const errorHandler = (error, component) => onErrorHandler(error, component, propsWithGetBasket)
+
     const buttonConfig = {
         showPayButton: true,
         isExpress: true,
@@ -286,15 +287,18 @@ export const getAppleButtonConfig = (props = {}) => {
 export const onErrorHandler = async (error, component, props) => {
     try {
         const basket = props.getBasket()
+        const isTemporaryBasket = basket?.temporaryBasket === true || props.isExpressPdp
         const paymentCancelExpressService = new PaymentCancelExpressService(
             props.token,
             props.customerId,
             basket?.basketId,
             props.site
         )
-        await paymentCancelExpressService.paymentCancelExpress()
-        props.navigate(`/checkout?error=true`)
-        return {cancelled: true}
+        await paymentCancelExpressService.paymentCancelExpress({
+            deleteTempBasket: isTemporaryBasket
+        })
+
+        return {cancelled: true, basketDeleted: isTemporaryBasket}
     } catch (err) {
         console.error('Error during express payment cancellation:', err)
         return {cancelled: false, error: err.message}

--- a/packages/adyen-salesforce-pwa/lib/services/payment-cancel-express.js
+++ b/packages/adyen-salesforce-pwa/lib/services/payment-cancel-express.js
@@ -8,10 +8,11 @@ export class PaymentCancelExpressService {
         this.apiClient = new ApiClient(this.baseUrl, token, customerId, basketId, site)
     }
 
-    async paymentCancelExpress() {
+    async paymentCancelExpress(options = {}) {
+        const {deleteTempBasket = false} = options
         const res = await this.apiClient.post({
             path: '/cancel/express',
-            body: JSON.stringify({})
+            body: JSON.stringify({deleteTempBasket})
         })
         if (res.status >= 300) {
             const errorData = await res


### PR DESCRIPTION


<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- delete temporary basket for applepay pdp when applepay dialog closes
- What existing problem does this pull request solve?
- delete temporary basket for applepay pdp when applepay dialog closes


## Tested scenarios
Description of tested scenarios:
Applepay on pdp

**Fixed issue**:  SFI-1499
