### PR TITLE
[SFI-1573] Add E2E tests for giftcards + LPMs (iDEAL, PayPal)

### DIFF
--- a/packages/e2e-tests/tests/giftCard.spec.js
+++ b/packages/e2e-tests/tests/giftCard.spec.js
@@ -3,8 +3,10 @@ import {ScenarioHelper} from '../helpers/ScenarioHelper.js'
 import {ShopperData} from '../data/shopperData.js'
 import {PaymentHelper} from '../helpers/PaymentHelper.js'
 import {CardData} from '../data/cardData.js'
+import {LocaleData} from '../data/localeData'
 
 const user_US = new ShopperData().US
+const user_FR = new ShopperData().FR
 const giftCard = new CardData().giftCard
 const threeDs2 = new CardData().threeDs2
 
@@ -31,6 +33,40 @@ test.describe('Payments through PWA UI', () => {
         )
         await paymentPage.clickPay()
         await paymentPage.validate3DS2('password')
+        await scenarios.verifySuccessfulOrder()
+    })
+
+    test('gift card + iDEAL should redirect', async ({page}) => {
+        const scenarios = new ScenarioHelper(page, new LocaleData().FR)
+        await scenarios.visitStore()
+        await scenarios.setupCart()
+        await scenarios.arrangeShippingAndProceedToPayment(user_FR)
+
+        const paymentPage = new PaymentHelper(page)
+        await paymentPage.selectPaymentType(giftCard.brand)
+        await paymentPage.fillGiftCardInfo(giftCard.cardNumber, giftCard.pin)
+        await paymentPage.clickPay()
+        await paymentPage.addedGiftCardIsDisplayed()
+
+        await paymentPage.selectPaymentType('iDEAL')
+        await paymentPage.clickPay()
+        await paymentPage.waitForIdealLoad()
+    })
+
+    test('gift card + PayPal payment should succeed', async ({page}) => {
+        const scenarios = new ScenarioHelper(page)
+        await scenarios.visitStore()
+        await scenarios.setupCart()
+        await scenarios.arrangeShippingAndProceedToPayment(user_US)
+
+        const paymentPage = new PaymentHelper(page)
+        await paymentPage.selectPaymentType(giftCard.brand)
+        await paymentPage.fillGiftCardInfo(giftCard.cardNumber, giftCard.pin)
+        await paymentPage.clickPay()
+        await paymentPage.addedGiftCardIsDisplayed()
+
+        await paymentPage.selectPaymentType('PayPal')
+        await paymentPage.initiatePayPalPayment()
         await scenarios.verifySuccessfulOrder()
     })
 })


### PR DESCRIPTION
## Description

Extends E2E test coverage for gift cards to include combination flows with redirect and popup-based payment methods.

## Changes

- Added test: **gift card + iDEAL** (redirect flow, French locale)
- Added test: **gift card + PayPal** (popup flow, US locale)
- Added imports: `LocaleData` and `user_FR` shopper data

## Test coverage

1. ✅ Gift card + iDEAL (FR locale) → verifies redirect to ideal.nl
2. ✅ Gift card + PayPal (US locale) → completes full payment flow

## Related

- Ticket: [SFI-1573](https://youtrack.is.adyen.com/issue/SFI-1573)
- Existing tests preserved: gift card + credit card (3DS2)

## Checklist

- [x] Tests follow existing patterns and conventions
- [x] Reused existing helpers (ScenarioHelper, PaymentHelper)
- [x] No new dependencies or helper methods required
- [x] E2E tests pass
- [x] SonarQube quality gate passes