### PR TITLE
[SFI-1642] Recreate basket on error in payment details

### DIFF
--- a/packages/adyen-salesforce-pwa/README.md
+++ b/packages/adyen-salesforce-pwa/README.md
@@ -11,7 +11,7 @@ vulnerability, [create a GitHub issue](https://github.com/Adyen/adyen-salesforce
 Adyen Payments Composable Storefront Integration for B2C Commerce depends on:
 
 1. PWA v8
-2. [Adyen Web v6.21.0](https://www.npmjs.com/package/@adyen/adyen-web)
+2. [Adyen Web v6.34.0](https://www.npmjs.com/package/@adyen/adyen-web)
 3. [Adyen API Library for Node.js v29.1.0](https://www.npmjs.com/package/@adyen/api-library)
 4. Node v22 or later
 5. NPM v11 or later

--- a/packages/adyen-salesforce-pwa/lib/api/controllers/payments-details.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/payments-details.js
@@ -27,6 +27,9 @@ async function handlePaymentDetailsError(res, orderNo) {
     try {
         Logger.info('handlePaymentDetailsError', 'start')
         const adyenContext = res.locals.adyen
+        if (!adyenContext) {
+            return null
+        }
         let resolvedOrderNo = orderNo
 
         if (!resolvedOrderNo) {

--- a/packages/adyen-salesforce-pwa/lib/api/controllers/payments-details.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/payments-details.js
@@ -9,6 +9,7 @@ import {
 import {
     createOrderUsingOrderNo,
     failOrderAndReopenBasket,
+    getOpenOrderForShopper,
     updateOrderPaymentInstrument
 } from '../helpers/orderHelper.js'
 import AdyenClientProvider from '../models/adyenClientProvider'
@@ -26,12 +27,24 @@ async function handlePaymentDetailsError(res, orderNo) {
     try {
         Logger.info('handlePaymentDetailsError', 'start')
         const adyenContext = res.locals.adyen
-        if (orderNo) {
-            return await failOrderAndReopenBasket(adyenContext, orderNo)
+        let resolvedOrderNo = orderNo
+
+        if (!resolvedOrderNo) {
+            const hasBasket = !!adyenContext?.basket?.basketId
+            if (hasBasket) {
+                await revertCheckoutState(adyenContext, 'sendPaymentDetails')
+                return null
+            }
+            const openOrder = await getOpenOrderForShopper(
+                adyenContext.authorization,
+                adyenContext.customerId,
+                adyenContext.siteId
+            )
+            resolvedOrderNo = openOrder?.orderNo
         }
-        const hasBasket = !!adyenContext?.basket?.basketId
-        if (hasBasket) {
-            await revertCheckoutState(adyenContext, 'sendPaymentDetails')
+
+        if (resolvedOrderNo) {
+            return await failOrderAndReopenBasket(adyenContext, resolvedOrderNo)
         }
     } catch (err) {
         Logger.error('handlePaymentDetailsError', err.stack)

--- a/packages/adyen-salesforce-pwa/lib/api/controllers/tests/payments-details.test.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/tests/payments-details.test.js
@@ -19,6 +19,7 @@ jest.mock('../../helpers/paymentsHelper.js', () => ({
 jest.mock('../../helpers/orderHelper.js', () => ({
     createOrderUsingOrderNo: jest.fn(),
     failOrderAndReopenBasket: jest.fn(),
+    getOpenOrderForShopper: jest.fn(),
     updateOrderPaymentInstrument: jest.fn()
 }))
 
@@ -244,6 +245,43 @@ describe('payments details controller', () => {
             expect(orderHelper.failOrderAndReopenBasket).toHaveBeenCalled()
             const err = next.mock.calls[0][0]
             expect(err.newBasketId).toBe('newBasket789')
+        })
+
+        it('falls back to getOpenOrderForShopper when paymentsDetails throws without merchantReference', async () => {
+            res.locals.adyen.basket = {}
+            res.locals.adyen.authorization = 'Bearer token'
+            res.locals.adyen.customerId = 'cust-123'
+            res.locals.adyen.siteId = 'RefArch'
+            mockPaymentsDetails.mockRejectedValue(new Error('Network timeout'))
+            orderHelper.getOpenOrderForShopper.mockResolvedValue({orderNo: 'orphan-order-1'})
+            orderHelper.failOrderAndReopenBasket.mockResolvedValue('recovered-basket-id')
+
+            await sendPaymentDetails(req, res, next)
+
+            expect(orderHelper.getOpenOrderForShopper).toHaveBeenCalledWith(
+                'Bearer token',
+                'cust-123',
+                'RefArch'
+            )
+            expect(orderHelper.failOrderAndReopenBasket).toHaveBeenCalled()
+            const err = next.mock.calls[0][0]
+            expect(err.newBasketId).toBe('recovered-basket-id')
+        })
+
+        it('returns no newBasketId when no open order found and no basket exists', async () => {
+            res.locals.adyen.basket = {}
+            res.locals.adyen.authorization = 'Bearer token'
+            res.locals.adyen.customerId = 'cust-123'
+            res.locals.adyen.siteId = 'RefArch'
+            mockPaymentsDetails.mockRejectedValue(new Error('Network timeout'))
+            orderHelper.getOpenOrderForShopper.mockResolvedValue(null)
+
+            await sendPaymentDetails(req, res, next)
+
+            expect(orderHelper.getOpenOrderForShopper).toHaveBeenCalled()
+            expect(orderHelper.failOrderAndReopenBasket).not.toHaveBeenCalled()
+            const err = next.mock.calls[0][0]
+            expect(err.newBasketId).toBeUndefined()
         })
     })
 })


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
Recreate basket on error scenario
- What existing problem does this pull request solve?
Recreate failed orders

## Tested scenarios
Description of tested scenarios:
- Google Pay

**Fixed issue**:  SFI-1642
