### PR TITLE
[SFI-1624] fail order in case of authorisation success=false scenario

### DIFF
--- a/packages/int_adyen_PWA/cartridge/scripts/webhooks/eventHandlers/AUTHORISATION.js
+++ b/packages/int_adyen_PWA/cartridge/scripts/webhooks/eventHandlers/AUTHORISATION.js
@@ -75,8 +75,8 @@ function handleFailedAuthorisation(order) {
     AdyenLogs.info_log(`Authorization for order ${order.orderNo} was not successful.`);
     const statusValue = order.status.value;
     if (statusValue === Order.ORDER_STATUS_CREATED) {
-        order.trackOrderChange('Authorisation refused (success=false), failing order');
         Transaction.wrap(function () {
+            order.trackOrderChange('Authorisation refused (success=false), failing order');
             order.setConfirmationStatus(Order.CONFIRMATION_STATUS_NOTCONFIRMED);
             order.setPaymentStatus(Order.PAYMENT_STATUS_NOTPAID);
             order.setExportStatus(Order.EXPORT_STATUS_NOTEXPORTED);

--- a/packages/int_adyen_PWA/cartridge/scripts/webhooks/eventHandlers/AUTHORISATION.js
+++ b/packages/int_adyen_PWA/cartridge/scripts/webhooks/eventHandlers/AUTHORISATION.js
@@ -72,11 +72,17 @@ function handleSuccessfulAuthorisation(order, result) {
  * @param {dw.order.Order} order - The order object
  */
 function handleFailedAuthorisation(order) {
-    AdyenLogs.info_log(
-        `Authorization for order ${order.orderNo} was not successful - no update.`,
-    );
-    // Determine if payment was refused and was used Adyen payment method
-    if (order.status.value === Order.ORDER_STATUS_FAILED) {
+    AdyenLogs.info_log(`Authorization for order ${order.orderNo} was not successful.`);
+    const statusValue = order.status.value;
+    if (statusValue === Order.ORDER_STATUS_CREATED) {
+        order.trackOrderChange('Authorisation refused (success=false), failing order');
+        Transaction.wrap(function () {
+            order.setConfirmationStatus(Order.CONFIRMATION_STATUS_NOTCONFIRMED);
+            order.setPaymentStatus(Order.PAYMENT_STATUS_NOTPAID);
+            order.setExportStatus(Order.EXPORT_STATUS_NOTEXPORTED);
+            OrderMgr.failOrder(order, false);
+        });
+    } else if (statusValue === Order.ORDER_STATUS_FAILED) {
         Transaction.wrap(function () {
             order.setConfirmationStatus(Order.CONFIRMATION_STATUS_NOTCONFIRMED);
             order.setPaymentStatus(Order.PAYMENT_STATUS_NOTPAID);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Fail the order properly
- What existing problem does this pull request solve?
Dont keep the order in created state

## Tested scenarios
Description of tested scenarios:
- Failed payments/payment details calls
- Abandoned payment on redirect payments

**Fixed issue**:  SFI-1624
