### PR TITLE
[SFI-1622] save psp reference after payments call

### DIFF
--- a/packages/adyen-salesforce-pwa/lib/api/controllers/payments.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/payments.js
@@ -159,7 +159,7 @@ async function sendPayments(req, res, next) {
             checkoutResponse.isSuccessful &&
             response?.pspReference
         ) {
-            Logger.error(
+            Logger.info(
                 'sendPayments',
                 `updateOrderPaymentInstrument with psp reference: ${response?.pspReference}`
             )

--- a/packages/adyen-salesforce-pwa/lib/api/controllers/payments.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/payments.js
@@ -153,6 +153,35 @@ async function sendPayments(req, res, next) {
             )
         }
 
+        if (
+            preCreatedOrderNo &&
+            !checkoutResponse.isFinal &&
+            checkoutResponse.isSuccessful &&
+            response?.pspReference
+        ) {
+            Logger.error(
+                'sendPayments',
+                `updateOrderPaymentInstrument with psp reference: ${response?.pspReference}`
+            )
+            try {
+                await updateOrderPaymentInstrument(
+                    preCreatedOrderNo,
+                    adyenContext.siteId,
+                    response.pspReference,
+                    {
+                        pspReference: response.pspReference,
+                        cardInstallments: paymentRequest?.installments?.value,
+                        donationToken: response?.donationToken
+                    }
+                )
+            } catch (piErr) {
+                Logger.error(
+                    'sendPayments',
+                    `Failed to update payment instrument on order ${preCreatedOrderNo}: ${piErr.message}`
+                )
+            }
+        }
+
         if (checkoutResponse.isFinal && checkoutResponse.isSuccessful) {
             if (!preCreatedOrderNo) {
                 await adyenContext.basketService.addPaymentInstrument(

--- a/packages/adyen-salesforce-pwa/lib/api/controllers/tests/payments.test.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/tests/payments.test.js
@@ -175,6 +175,8 @@ describe('payments controller', () => {
         expect(orderHelper.createOrderUsingOrderNo).toHaveBeenCalled()
         // basket was consumed — must NOT attempt basket update
         expect(res.locals.adyen.basketService.update).not.toHaveBeenCalled()
+        // no pspReference in the 3DS challenge response — no PI update
+        expect(orderHelper.updateOrderPaymentInstrument).not.toHaveBeenCalled()
         expect(res.locals.response).toEqual({
             isFinal: false,
             isSuccessful: true,
@@ -182,6 +184,39 @@ describe('payments controller', () => {
             action: mockAction,
             order: undefined,
             resultCode: RESULT_CODES.CHALLENGE_SHOPPER
+        })
+        expect(next).toHaveBeenCalledWith()
+    })
+
+    it('standard payment (scheme): persists pspReference on pre-created order on redirect (non-final)', async () => {
+        const mockAction = {type: 'redirect', url: 'https://ideal.nl'}
+        mockPayments.mockResolvedValue({
+            resultCode: RESULT_CODES.REDIRECT_SHOPPER,
+            action: mockAction,
+            pspReference: 'psp-redirect-123'
+        })
+
+        await sendPayments(req, res, next)
+
+        expect(orderHelper.createOrderUsingOrderNo).toHaveBeenCalled()
+        expect(res.locals.adyen.basketService.update).not.toHaveBeenCalled()
+        expect(orderHelper.updateOrderPaymentInstrument).toHaveBeenCalledWith(
+            '123',
+            'RefArch',
+            'psp-redirect-123',
+            {
+                pspReference: 'psp-redirect-123',
+                cardInstallments: undefined,
+                donationToken: undefined
+            }
+        )
+        expect(res.locals.response).toEqual({
+            isFinal: false,
+            isSuccessful: true,
+            merchantReference: '123',
+            action: mockAction,
+            order: undefined,
+            resultCode: RESULT_CODES.REDIRECT_SHOPPER
         })
         expect(next).toHaveBeenCalledWith()
     })

--- a/packages/int_adyen_PWA/cartridge/rest-apis/adyen-order/updateOrderPaymentInstrument.js
+++ b/packages/int_adyen_PWA/cartridge/rest-apis/adyen-order/updateOrderPaymentInstrument.js
@@ -1,6 +1,7 @@
 const RESTResponseMgr = require('dw/system/RESTResponseMgr');
 const OrderMgr = require('dw/order/OrderMgr');
 const Logger = require('dw/system/Logger');
+const Transaction = require('dw/system/Transaction');
 
 /**
  * Implements the PATCH method for the adyen-order API.
@@ -30,13 +31,15 @@ exports.updateOrderPaymentInstrument = function () {
         RESTResponseMgr.createError(404, 'not_found', 'Payment instrument not found').render();
         return;
       }
-      allowedCustomProperties.forEach((prop) => {
-        if (
-          Object.prototype.hasOwnProperty.call(customProperties, prop) &&
-          customProperties[prop] !== undefined
-        ) {
-          paymentInstrument.custom[prop] = customProperties[prop];
-        }
+      Transaction.wrap(function () {
+        allowedCustomProperties.forEach((prop) => {
+          if (
+            Object.prototype.hasOwnProperty.call(customProperties, prop) &&
+            customProperties[prop] !== undefined
+          ) {
+            paymentInstrument.custom[prop] = customProperties[prop];
+          }
+        });
       });
       RESTResponseMgr.createSuccess({}, 200).render();
     } else {

--- a/packages/int_adyen_PWA/cartridge/scripts/utils/notificationEventHelper.js
+++ b/packages/int_adyen_PWA/cartridge/scripts/utils/notificationEventHelper.js
@@ -101,25 +101,41 @@ function isWebhookSuccessful(customObj) {
  * @returns {boolean} - True if any Adyen instrument was found
  */
 function updatePaymentTransaction(order, customObj, transactionType) {
-    const paymentInstruments = order.getPaymentInstruments();
-    Object.values(paymentInstruments).forEach((pi) => {
-        const processor = PaymentMgr.getPaymentMethod(
-            pi.getPaymentMethod(),
-        ).getPaymentProcessor();
-        if (pi.custom.pspReference === customObj.custom.pspReference) {
-            const amount = new Money(customObj.custom.value, customObj.custom.currency);
-            const divideBy = getDivisorForCurrency(amount);
-            const transactionAmount = amount.divide(divideBy);
-            Transaction.wrap(function () {
-                pi.paymentTransaction.setTransactionID(customObj.custom.pspReference);
-                pi.paymentTransaction.setType(transactionType);
-                pi.paymentTransaction.setPaymentProcessor(processor);
-                pi.paymentTransaction.setAmount(transactionAmount);
-                pi.paymentTransaction.setAccountID(customObj.custom.merchantAccountCode);
-                pi.paymentTransaction.custom.notification_data = customObj.custom.log;
-            })
-        }
-    });
+    const paymentInstruments = order.getPaymentInstruments().toArray();
+
+    const applyUpdate = (pi) => {
+        const processor = PaymentMgr.getPaymentMethod(pi.getPaymentMethod()).getPaymentProcessor();
+        const amount = new Money(customObj.custom.value, customObj.custom.currency);
+        const divideBy = getDivisorForCurrency(amount);
+        const transactionAmount = amount.divide(divideBy);
+        Transaction.wrap(function () {
+            pi.custom.pspReference = customObj.custom.pspReference;
+            pi.paymentTransaction.setTransactionID(customObj.custom.pspReference);
+            pi.paymentTransaction.setType(transactionType);
+            pi.paymentTransaction.setPaymentProcessor(processor);
+            pi.paymentTransaction.setAmount(transactionAmount);
+            pi.paymentTransaction.setAccountID(customObj.custom.merchantAccountCode);
+            pi.paymentTransaction.custom.notification_data = customObj.custom.log;
+        });
+    };
+
+    const matched = paymentInstruments.filter(
+        (pi) => pi.custom.pspReference === customObj.custom.pspReference
+    );
+
+    if (matched.length) {
+        matched.forEach(applyUpdate);
+        return;
+    }
+
+    // Fallback: the /payments/details response was dropped (e.g. shopper closed the redirect
+    // tab), so the PSP reference was never stored on the order. Recover it from the webhook.
+    const fallbackPi = paymentInstruments.find(
+        (pi) => pi.custom.paymentMethodType !== 'giftcard'
+    );
+    if (fallbackPi) {
+        applyUpdate(fallbackPi);
+    }
 }
 
 module.exports = {

--- a/packages/int_adyen_PWA/cartridge/scripts/utils/notificationEventHelper.js
+++ b/packages/int_adyen_PWA/cartridge/scripts/utils/notificationEventHelper.js
@@ -104,7 +104,11 @@ function updatePaymentTransaction(order, customObj, transactionType) {
     const paymentInstruments = order.getPaymentInstruments().toArray();
 
     const applyUpdate = (pi) => {
-        const processor = PaymentMgr.getPaymentMethod(pi.getPaymentMethod()).getPaymentProcessor();
+        const paymentMethod = PaymentMgr.getPaymentMethod(pi.getPaymentMethod());
+        const processor = paymentMethod ? paymentMethod.getPaymentProcessor() : null;
+        if (!processor) {
+            return;
+        }
         const amount = new Money(customObj.custom.value, customObj.custom.currency);
         const divideBy = getDivisorForCurrency(amount);
         const transactionAmount = amount.divide(divideBy);
@@ -125,7 +129,7 @@ function updatePaymentTransaction(order, customObj, transactionType) {
 
     if (matched.length) {
         matched.forEach(applyUpdate);
-        return;
+        return true;
     }
 
     // Fallback: the /payments/details response was dropped (e.g. shopper closed the redirect
@@ -135,7 +139,9 @@ function updatePaymentTransaction(order, customObj, transactionType) {
     );
     if (fallbackPi) {
         applyUpdate(fallbackPi);
+        return true;
     }
+    return false;
 }
 
 module.exports = {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
Fill in missing psp reference after abandoned payment
- What existing problem does this pull request solve?
Merchants can utilize the psp reference for refund purposes

## Tested scenarios
Description of tested scenarios:
- Redirect payments
- Card payments
- LPM

**Fixed issue**:  SFI-1622
