### PR TITLE
[SFI-1701] Prevent duplicate merchant reference reuse

### DIFF
--- a/packages/adyen-salesforce-pwa/lib/api/controllers/order-number.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/order-number.js
@@ -1,7 +1,8 @@
 import Logger from '../models/logger'
 import {AdyenError} from '../models/AdyenError'
-import {ERROR_MESSAGE} from '../../utils/constants.mjs'
+import {ERROR_MESSAGE, ORDER} from '../../utils/constants.mjs'
 import {CustomShopperOrderApiClient} from '../models/customShopperOrderApi.js'
+import {createShopperOrderClient} from '../helpers/orderHelper.js'
 
 /**
  * An Express middleware that generates a new unique order number and returns it to the client.
@@ -22,9 +23,37 @@ async function getOrderNumber(req, res, next) {
 
         const existingOrderNo = adyenContext.basket?.c_orderNo
         if (existingOrderNo) {
-            Logger.info('getOrderNumber', `Reusing existing order number: ${existingOrderNo}`)
-            res.locals.response = {orderNo: existingOrderNo}
-            return next()
+            try {
+                const shopperOrders = createShopperOrderClient(
+                    adyenContext.authorization,
+                    adyenContext.siteId
+                )
+                const existingOrder = await shopperOrders.getOrder({
+                    parameters: {orderNo: existingOrderNo}
+                })
+                if (
+                    !existingOrder?.orderNo ||
+                    existingOrder.status === ORDER.ORDER_STATUS_CREATED
+                ) {
+                    Logger.info(
+                        'getOrderNumber',
+                        `Reusing existing order number: ${existingOrderNo}`
+                    )
+                    res.locals.response = {orderNo: existingOrderNo}
+                    return next()
+                }
+                Logger.info(
+                    'getOrderNumber',
+                    `Order number ${existingOrderNo} is ${existingOrder.status}; generating a new one`
+                )
+            } catch (err) {
+                Logger.info(
+                    'getOrderNumber',
+                    `Could not verify order number ${existingOrderNo} (${err.message}); reusing it`
+                )
+                res.locals.response = {orderNo: existingOrderNo}
+                return next()
+            }
         }
 
         const customOrderApi = new CustomShopperOrderApiClient(adyenContext.siteId)

--- a/packages/adyen-salesforce-pwa/lib/api/controllers/order-number.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/order-number.js
@@ -47,10 +47,17 @@ async function getOrderNumber(req, res, next) {
                     `Order number ${existingOrderNo} is ${existingOrder.status}; generating a new one`
                 )
             } catch (err) {
-                Logger.info(
-                    'getOrderNumber',
-                    `Could not verify order number ${existingOrderNo} (${err.message}); reusing it`
-                )
+                if (err?.statusCode === 404 || err?.status === 404) {
+                    Logger.info(
+                        'getOrderNumber',
+                        `Order number ${existingOrderNo} does not exist yet; reusing it`
+                    )
+                } else {
+                    Logger.error(
+                        'getOrderNumber',
+                        `Could not verify order number ${existingOrderNo} (${err.message}); reusing it`
+                    )
+                }
                 res.locals.response = {orderNo: existingOrderNo}
                 return next()
             }

--- a/packages/adyen-salesforce-pwa/lib/api/controllers/terminal-payment.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/terminal-payment.js
@@ -34,6 +34,7 @@ async function createTerminalPayment(req, res, next) {
     let orderNo = null
     let serviceId
     let terminalId
+    let terminalPaymentStarted = false
 
     try {
         Logger.info('createTerminalPayment', 'start')
@@ -86,6 +87,7 @@ async function createTerminalPayment(req, res, next) {
             .build()
 
         const terminalCloudApi = new AdyenClientProvider(adyenContext).getTerminalClient()
+        terminalPaymentStarted = true
         const response = await terminalCloudApi.sync(terminalApiRequest)
         const paymentResult = parsePaymentResponse(response)
         if (paymentResult.result === 'Failure') {
@@ -150,7 +152,7 @@ async function createTerminalPayment(req, res, next) {
     } catch (err) {
         Logger.error('createTerminalPayment', err.message)
 
-        if (serviceId && terminalId) {
+        if (terminalPaymentStarted && serviceId && terminalId) {
             try {
                 await sendAbortRequest(res.locals.adyen, serviceId, terminalId)
             } catch (abortErr) {

--- a/packages/adyen-salesforce-pwa/lib/api/controllers/tests/order-number.test.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/tests/order-number.test.js
@@ -92,12 +92,35 @@ describe('getOrderNumber controller', () => {
             expect(mockBasketService.update).not.toHaveBeenCalled()
         })
 
-        it('should reuse the number when the order lookup fails', async () => {
+        it('should log and reuse the number when the order does not exist', async () => {
+            mockAdyenContext.basket.c_orderNo = 'UNUSED-ORDER-999'
+            mockGetOrder.mockRejectedValue(
+                Object.assign(new Error('Order not found'), {statusCode: 404})
+            )
+
+            await getOrderNumber(mockReq, mockRes, mockNext)
+
+            expect(Logger.info).toHaveBeenCalledWith(
+                'getOrderNumber',
+                'Order number UNUSED-ORDER-999 does not exist yet; reusing it'
+            )
+            expect(Logger.error).not.toHaveBeenCalled()
+            expect(mockRes.locals.response).toEqual({orderNo: 'UNUSED-ORDER-999'})
+            expect(CustomShopperOrderApiClient).not.toHaveBeenCalled()
+            expect(mockBasketService.update).not.toHaveBeenCalled()
+            expect(mockNext).toHaveBeenCalledWith()
+        })
+
+        it('should log unexpected lookup failures as errors before reusing the number', async () => {
             mockAdyenContext.basket.c_orderNo = 'UNVERIFIED-ORDER-999'
             mockGetOrder.mockRejectedValue(new Error('Lookup failed'))
 
             await getOrderNumber(mockReq, mockRes, mockNext)
 
+            expect(Logger.error).toHaveBeenCalledWith(
+                'getOrderNumber',
+                'Could not verify order number UNVERIFIED-ORDER-999 (Lookup failed); reusing it'
+            )
             expect(mockRes.locals.response).toEqual({orderNo: 'UNVERIFIED-ORDER-999'})
             expect(CustomShopperOrderApiClient).not.toHaveBeenCalled()
             expect(mockBasketService.update).not.toHaveBeenCalled()

--- a/packages/adyen-salesforce-pwa/lib/api/controllers/tests/order-number.test.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/tests/order-number.test.js
@@ -1,10 +1,16 @@
 import getOrderNumber from '../order-number'
 import Logger from '../../models/logger'
 import {CustomShopperOrderApiClient} from '../../models/customShopperOrderApi'
+import {createShopperOrderClient} from '../../helpers/orderHelper.js'
 
 // Mock dependencies
 jest.mock('../../models/logger')
 jest.mock('../../models/customShopperOrderApi')
+jest.mock('../../helpers/orderHelper.js', () => ({
+    createShopperOrderClient: jest.fn()
+}))
+
+const mockGetOrder = jest.fn()
 
 describe('getOrderNumber controller', () => {
     let mockReq, mockRes, mockNext, mockAdyenContext, mockBasketService
@@ -32,6 +38,8 @@ describe('getOrderNumber controller', () => {
             }
         }
         mockNext = jest.fn()
+        mockGetOrder.mockResolvedValue({})
+        createShopperOrderClient.mockReturnValue({getOrder: mockGetOrder})
 
         // Mock the CustomShopperOrderApiClient constructor
         CustomShopperOrderApiClient.mockImplementation(() => ({
@@ -55,12 +63,14 @@ describe('getOrderNumber controller', () => {
     })
 
     describe('when existing order number is present', () => {
-        it('should reuse existing order number and not generate new one', async () => {
+        it('should reuse the number when no order exists', async () => {
             mockAdyenContext.basket.c_orderNo = 'EXISTING-ORDER-999'
 
             await getOrderNumber(mockReq, mockRes, mockNext)
 
-            expect(Logger.info).toHaveBeenCalledWith('getOrderNumber', 'start')
+            expect(mockGetOrder).toHaveBeenCalledWith({
+                parameters: {orderNo: 'EXISTING-ORDER-999'}
+            })
             expect(Logger.info).toHaveBeenCalledWith(
                 'getOrderNumber',
                 'Reusing existing order number: EXISTING-ORDER-999'
@@ -70,6 +80,48 @@ describe('getOrderNumber controller', () => {
             expect(CustomShopperOrderApiClient).not.toHaveBeenCalled()
             expect(mockBasketService.update).not.toHaveBeenCalled()
         })
+
+        it('should reuse the number when its order is still created', async () => {
+            mockAdyenContext.basket.c_orderNo = 'CREATED-ORDER-999'
+            mockGetOrder.mockResolvedValue({orderNo: 'CREATED-ORDER-999', status: 'created'})
+
+            await getOrderNumber(mockReq, mockRes, mockNext)
+
+            expect(mockRes.locals.response).toEqual({orderNo: 'CREATED-ORDER-999'})
+            expect(CustomShopperOrderApiClient).not.toHaveBeenCalled()
+            expect(mockBasketService.update).not.toHaveBeenCalled()
+        })
+
+        it('should reuse the number when the order lookup fails', async () => {
+            mockAdyenContext.basket.c_orderNo = 'UNVERIFIED-ORDER-999'
+            mockGetOrder.mockRejectedValue(new Error('Lookup failed'))
+
+            await getOrderNumber(mockReq, mockRes, mockNext)
+
+            expect(mockRes.locals.response).toEqual({orderNo: 'UNVERIFIED-ORDER-999'})
+            expect(CustomShopperOrderApiClient).not.toHaveBeenCalled()
+            expect(mockBasketService.update).not.toHaveBeenCalled()
+            expect(mockNext).toHaveBeenCalledWith()
+        })
+    })
+
+    describe('when existing order number belongs to a placed order', () => {
+        it.each(['new', 'completed', 'cancelled', 'failed', 'failed_with_reopen', 'unknown'])(
+            'should replace a %s order number before starting another payment',
+            async (status) => {
+                mockAdyenContext.basket.c_orderNo = 'SPENT-ORDER-999'
+                mockGetOrder.mockResolvedValue({orderNo: 'SPENT-ORDER-999', status})
+
+                await getOrderNumber(mockReq, mockRes, mockNext)
+
+                expect(mockGetOrder).toHaveBeenCalledWith({
+                    parameters: {orderNo: 'SPENT-ORDER-999'}
+                })
+                expect(mockBasketService.update).toHaveBeenCalledWith({c_orderNo: 'ORDER-12345'})
+                expect(mockRes.locals.response).toEqual({orderNo: 'ORDER-12345'})
+                expect(mockNext).toHaveBeenCalledWith()
+            }
+        )
     })
 
     describe('when no existing order number', () => {

--- a/packages/adyen-salesforce-pwa/lib/api/controllers/tests/terminal-payment.test.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/tests/terminal-payment.test.js
@@ -306,6 +306,19 @@ describe('createTerminalPayment controller', () => {
         expect(res.locals.response.newBasketId).toBe('new-basket-123')
     })
 
+    it('should not send a terminal abort when an existing order is rejected', async () => {
+        const orderError = Object.assign(new Error(ERROR_MESSAGE.ORDER_ALREADY_PLACED), {
+            statusCode: 409
+        })
+        orderHelper.createOrderUsingOrderNo.mockRejectedValue(orderError)
+
+        await createTerminalPayment(req, res, next)
+
+        expect(mockSync).not.toHaveBeenCalled()
+        expect(orderHelper.failOrderAndReopenBasket).not.toHaveBeenCalled()
+        expect(next).toHaveBeenCalledWith(orderError)
+    })
+
     it('should send abort and fail order on communication error', async () => {
         mockSync.mockRejectedValueOnce(new Error('Network timeout')).mockResolvedValueOnce('ok')
 

--- a/packages/adyen-salesforce-pwa/lib/api/helpers/orderHelper.js
+++ b/packages/adyen-salesforce-pwa/lib/api/helpers/orderHelper.js
@@ -8,11 +8,11 @@ import {
     createShopperBasketsClient,
     getBasket,
     getCurrentBasketForAuthorizedShopper
-} from '../helpers/basketHelper.js'
-import {createShopperCustomerClient, getCustomerBaskets} from '../helpers/customerHelper.js'
+} from './basketHelper'
+import {createShopperCustomerClient, getCustomerBaskets} from './customerHelper'
 import {BasketService} from '../models/basketService.js'
 import {ERROR_MESSAGE, ORDER} from '../../utils/constants.mjs'
-import {cleanupReopenedBasket} from '../helpers/paymentsHelper.js'
+import {cleanupReopenedBasket} from './paymentsHelper'
 import Logger from '../models/logger.js'
 
 /**
@@ -116,6 +116,7 @@ export async function failOrderAndReopenBasket(adyenContext, orderNo, options = 
                 const tempRes = {locals: {adyen: tempContext}}
                 tempContext.basketService = new BasketService(tempContext, tempRes)
                 await cleanupReopenedBasket(tempContext, 'failOrderAndReopenBasket')
+                return currentBasket.basketId
             } catch (err) {
                 Logger.error(
                     'failOrderAndReopenBasket',

--- a/packages/adyen-salesforce-pwa/lib/api/helpers/orderHelper.js
+++ b/packages/adyen-salesforce-pwa/lib/api/helpers/orderHelper.js
@@ -5,11 +5,11 @@ import {OrderApiClient} from '../models/orderApi.js'
 import {CustomShopperOrderApiClient} from '../models/customShopperOrderApi.js'
 import {CustomAdminOrderApiClient} from '../models/customAdminOrderApi.js'
 import {
+    createShopperBasketsClient,
     getBasket,
-    getCurrentBasketForAuthorizedShopper,
-    createShopperBasketsClient
+    getCurrentBasketForAuthorizedShopper
 } from '../helpers/basketHelper.js'
-import {getCustomerBaskets, createShopperCustomerClient} from '../helpers/customerHelper.js'
+import {createShopperCustomerClient, getCustomerBaskets} from '../helpers/customerHelper.js'
 import {BasketService} from '../models/basketService.js'
 import {ERROR_MESSAGE, ORDER} from '../../utils/constants.mjs'
 import {cleanupReopenedBasket} from '../helpers/paymentsHelper.js'
@@ -94,6 +94,36 @@ export async function failOrderAndReopenBasket(adyenContext, orderNo, options = 
         throw new AdyenError(ERROR_MESSAGE.INVALID_ORDER, 404)
     }
     if (reopenBasket) {
+        if (order.status !== ORDER.ORDER_STATUS_CREATED) {
+            Logger.info(
+                'failOrderAndReopenBasket',
+                `Order ${orderNo} is ${order.status}; skipping fail and reopen`
+            )
+            try {
+                const currentBasket = await getCurrentBasketForAuthorizedShopper(
+                    authorization,
+                    customerId,
+                    siteId
+                )
+                if (currentBasket?.c_orderNo !== orderNo) {
+                    Logger.info(
+                        'failOrderAndReopenBasket',
+                        `Current basket does not reference order ${orderNo}; skipping cleanup`
+                    )
+                    return null
+                }
+                const tempContext = {...adyenContext, basket: currentBasket}
+                const tempRes = {locals: {adyen: tempContext}}
+                tempContext.basketService = new BasketService(tempContext, tempRes)
+                await cleanupReopenedBasket(tempContext, 'failOrderAndReopenBasket')
+            } catch (err) {
+                Logger.error(
+                    'failOrderAndReopenBasket',
+                    `Failed to clean up current basket: ${err.message}`
+                )
+            }
+            return null
+        }
         try {
             const shopperBaskets = createShopperBasketsClient(authorization, siteId)
             const {baskets} = await getCustomerBaskets(authorization, customerId, siteId)
@@ -111,7 +141,6 @@ export async function failOrderAndReopenBasket(adyenContext, orderNo, options = 
             )
         }
     }
-
     const orderApi = new OrderApiClient(siteId)
     const response = await orderApi.updateOrderStatus(
         order.orderNo,
@@ -160,13 +189,23 @@ export async function createOrderUsingOrderNo(adyenContext) {
         throw new AdyenError(ERROR_MESSAGE.ORDER_NUMBER_NOT_FOUND, 400)
     }
     const shopperOrders = createShopperOrderClient(authorization, siteId)
-    const order = await shopperOrders.getOrder({
-        parameters: {
-            orderNo: orderNo
+    let order
+    try {
+        order = await shopperOrders.getOrder({
+            parameters: {
+                orderNo: orderNo
+            }
+        })
+    } catch (err) {
+        if (err?.statusCode !== 404 && err?.status !== 404) {
+            throw err
         }
-    })
-    if (order?.orderNo) {
+    }
+    if (order?.orderNo && order.status === ORDER.ORDER_STATUS_CREATED) {
         return order
+    }
+    if (order?.orderNo) {
+        throw new AdyenError(ERROR_MESSAGE.ORDER_ALREADY_PLACED, 409)
     }
     const customOrderApi = new CustomShopperOrderApiClient(siteId)
     return await customOrderApi.createOrder(authorization, basketId, customerId, orderNo, currency)

--- a/packages/adyen-salesforce-pwa/lib/api/helpers/tests/orderHelper.test.js
+++ b/packages/adyen-salesforce-pwa/lib/api/helpers/tests/orderHelper.test.js
@@ -322,6 +322,7 @@ describe('orderHelper', () => {
         it('should clear the shipping address on the reopened basket when removeShippingAddress is true', async () => {
             const mockOrder = {
                 orderNo: 'order123',
+                status: ORDER.ORDER_STATUS_CREATED,
                 customerInfo: {customerId: 'customer-abc'}
             }
             mockGetOrder.mockResolvedValue(mockOrder)
@@ -348,6 +349,7 @@ describe('orderHelper', () => {
         it('should not clear the shipping address by default', async () => {
             const mockOrder = {
                 orderNo: 'order123',
+                status: ORDER.ORDER_STATUS_CREATED,
                 customerInfo: {customerId: 'customer-abc'}
             }
             mockGetOrder.mockResolvedValue(mockOrder)

--- a/packages/adyen-salesforce-pwa/lib/api/helpers/tests/orderHelper.test.js
+++ b/packages/adyen-salesforce-pwa/lib/api/helpers/tests/orderHelper.test.js
@@ -230,7 +230,7 @@ describe('orderHelper', () => {
                     expect.objectContaining({c_orderNo: ''})
                 )
                 expect(mockRemoveAllPaymentInstruments).toHaveBeenCalled()
-                expect(result).toBeNull()
+                expect(result).toBe('current-basket-456')
             }
         )
 

--- a/packages/adyen-salesforce-pwa/lib/api/helpers/tests/orderHelper.test.js
+++ b/packages/adyen-salesforce-pwa/lib/api/helpers/tests/orderHelper.test.js
@@ -133,6 +133,9 @@ describe('orderHelper', () => {
     describe('failOrderAndReopenBasket', () => {
         const mockGetOrder = jest.fn()
         const mockUpdateOrderStatus = jest.fn()
+        const mockDeleteBasket = jest.fn()
+        const mockBasketUpdate = jest.fn()
+        const mockRemoveAllPaymentInstruments = jest.fn()
         const mockAdyenContext = {
             authorization: 'auth',
             customerId: 'customer-abc',
@@ -140,6 +143,9 @@ describe('orderHelper', () => {
         }
 
         beforeEach(() => {
+            getConfig.mockReturnValue({
+                app: {commerceAPI: {parameters: {siteId: 'RefArch'}}}
+            })
             ShopperOrders.mockImplementation(() => ({
                 getOrder: mockGetOrder
             }))
@@ -148,15 +154,20 @@ describe('orderHelper', () => {
             }))
             getCustomerBaskets.mockResolvedValue({baskets: []})
             getBasket.mockResolvedValue({basketId: 'new-basket-123'})
+            getCurrentBasketForAuthorizedShopper.mockResolvedValue({basketId: 'current-basket-456'})
+            createShopperBasketsClient.mockReturnValue({deleteBasket: mockDeleteBasket})
+            mockBasketUpdate.mockResolvedValue({})
+            mockRemoveAllPaymentInstruments.mockResolvedValue({})
             BasketService.mockImplementation(() => ({
-                update: jest.fn().mockResolvedValue({}),
-                removeAllPaymentInstruments: jest.fn().mockResolvedValue({})
+                update: mockBasketUpdate,
+                removeAllPaymentInstruments: mockRemoveAllPaymentInstruments
             }))
         })
 
         it('should fail the order and reopen the basket successfully', async () => {
             const mockOrder = {
                 orderNo: 'order123',
+                status: ORDER.ORDER_STATUS_CREATED,
                 customerInfo: {customerId: 'customer-abc'}
             }
             mockGetOrder.mockResolvedValue(mockOrder)
@@ -186,17 +197,65 @@ describe('orderHelper', () => {
         it('should throw AdyenError if customer ID does not match', async () => {
             const mockOrder = {
                 orderNo: 'order123',
+                status: ORDER.ORDER_STATUS_FAILED,
                 customerInfo: {customerId: 'different-customer'}
             }
             mockGetOrder.mockResolvedValue(mockOrder)
             await expect(failOrderAndReopenBasket(mockAdyenContext, 'order123')).rejects.toThrow(
                 ERROR_MESSAGE.INVALID_ORDER
             )
+            expect(getCurrentBasketForAuthorizedShopper).not.toHaveBeenCalled()
+            expect(mockBasketUpdate).not.toHaveBeenCalled()
+        })
+
+        it.each(['new', 'completed', 'cancelled', 'failed', 'failed_with_reopen', 'unknown'])(
+            'should clean the current basket without failing an existing %s order',
+            async (status) => {
+                mockGetOrder.mockResolvedValue({
+                    orderNo: 'order123',
+                    status,
+                    customerInfo: {customerId: 'customer-abc'}
+                })
+                getCustomerBaskets.mockResolvedValue({baskets: [{basketId: 'current-basket-456'}]})
+                getCurrentBasketForAuthorizedShopper.mockResolvedValue({
+                    basketId: 'current-basket-456',
+                    c_orderNo: 'order123'
+                })
+
+                const result = await failOrderAndReopenBasket(mockAdyenContext, 'order123')
+
+                expect(mockDeleteBasket).not.toHaveBeenCalled()
+                expect(mockUpdateOrderStatus).not.toHaveBeenCalled()
+                expect(mockBasketUpdate).toHaveBeenCalledWith(
+                    expect.objectContaining({c_orderNo: ''})
+                )
+                expect(mockRemoveAllPaymentInstruments).toHaveBeenCalled()
+                expect(result).toBeNull()
+            }
+        )
+
+        it('should not clean a newer basket for a stale cancelled order number', async () => {
+            mockGetOrder.mockResolvedValue({
+                orderNo: 'stale-order',
+                status: ORDER.ORDER_STATUS_FAILED,
+                customerInfo: {customerId: 'customer-abc'}
+            })
+            getCurrentBasketForAuthorizedShopper.mockResolvedValue({
+                basketId: 'current-basket-456',
+                c_orderNo: 'new-order'
+            })
+
+            const result = await failOrderAndReopenBasket(mockAdyenContext, 'stale-order')
+
+            expect(mockBasketUpdate).not.toHaveBeenCalled()
+            expect(mockRemoveAllPaymentInstruments).not.toHaveBeenCalled()
+            expect(result).toBeNull()
         })
 
         it('should handle basket deletion errors gracefully', async () => {
             const mockOrder = {
                 orderNo: 'order123',
+                status: ORDER.ORDER_STATUS_CREATED,
                 customerInfo: {customerId: 'customer-abc'}
             }
             mockGetOrder.mockResolvedValue(mockOrder)
@@ -220,6 +279,7 @@ describe('orderHelper', () => {
         it('should handle missing Location header', async () => {
             const mockOrder = {
                 orderNo: 'order123',
+                status: ORDER.ORDER_STATUS_CREATED,
                 customerInfo: {customerId: 'customer-abc'}
             }
             mockGetOrder.mockResolvedValue(mockOrder)
@@ -311,6 +371,7 @@ describe('orderHelper', () => {
         it('should handle basket cleanup errors', async () => {
             const mockOrder = {
                 orderNo: 'order123',
+                status: ORDER.ORDER_STATUS_CREATED,
                 customerInfo: {customerId: 'customer-abc'}
             }
             mockGetOrder.mockResolvedValue(mockOrder)
@@ -342,6 +403,9 @@ describe('orderHelper', () => {
         }
 
         beforeEach(() => {
+            getConfig.mockReturnValue({
+                app: {commerceAPI: {parameters: {siteId: 'RefArch'}}}
+            })
             ShopperOrders.mockImplementation(() => ({
                 getOrder: mockGetOrder
             }))
@@ -367,14 +431,53 @@ describe('orderHelper', () => {
             expect(result).toEqual({orderNo: 'order123'})
         })
 
-        it('should return existing order without re-creating if it already exists', async () => {
-            mockGetOrder.mockResolvedValue({orderNo: 'order123'}) // Order exists
+        it('should create an order when lookup reports it does not exist', async () => {
+            const notFoundError = Object.assign(new Error('Order not found'), {statusCode: 404})
+            mockGetOrder.mockRejectedValue(notFoundError)
+            mockCreateOrder.mockResolvedValue({orderNo: 'order123'})
 
             const result = await createOrderUsingOrderNo(mockAdyenContext)
 
+            expect(mockCreateOrder).toHaveBeenCalledWith(
+                'auth',
+                'basket-abc',
+                'customer-abc',
+                'order123',
+                'USD'
+            )
             expect(result).toEqual({orderNo: 'order123'})
+        })
+
+        it('should propagate non-404 lookup errors', async () => {
+            const apiError = Object.assign(new Error('Order lookup failed'), {statusCode: 500})
+            mockGetOrder.mockRejectedValue(apiError)
+
+            await expect(createOrderUsingOrderNo(mockAdyenContext)).rejects.toBe(apiError)
             expect(mockCreateOrder).not.toHaveBeenCalled()
         })
+
+        it('should return an existing created order without re-creating it', async () => {
+            const existingOrder = {orderNo: 'order123', status: ORDER.ORDER_STATUS_CREATED}
+            mockGetOrder.mockResolvedValue(existingOrder)
+
+            const result = await createOrderUsingOrderNo(mockAdyenContext)
+
+            expect(result).toEqual(existingOrder)
+            expect(mockCreateOrder).not.toHaveBeenCalled()
+        })
+
+        it.each(['new', 'completed', 'cancelled', 'failed', 'failed_with_reopen', 'unknown'])(
+            'should reject an existing %s order',
+            async (status) => {
+                mockGetOrder.mockResolvedValue({orderNo: 'order123', status})
+
+                await expect(createOrderUsingOrderNo(mockAdyenContext)).rejects.toMatchObject({
+                    message: ERROR_MESSAGE.ORDER_ALREADY_PLACED,
+                    statusCode: 409
+                })
+                expect(mockCreateOrder).not.toHaveBeenCalled()
+            }
+        )
 
         it('should throw AdyenError when order number is missing', async () => {
             const contextWithoutOrderNo = {

--- a/packages/adyen-salesforce-pwa/lib/components/adyenCheckout.jsx
+++ b/packages/adyen-salesforce-pwa/lib/components/adyenCheckout.jsx
@@ -60,7 +60,10 @@ const AdyenCheckoutComponent = ({
     const adyenOrderRef = useRef(null)
     const [isLoading, setIsLoading] = useState(false)
     const [adyenStateData, setAdyenStateData] = useState(null)
-    const [internalOrderNo, setInternalOrderNo] = useState(null)
+    const [orderNumberState, setOrderNumberState] = useState({
+        sourceOrderNo: null,
+        currentOrderNo: null
+    })
     const [internalAdyenOrder, setInternalAdyenOrder] = useState(null)
     const [internalAdyenAction, setInternalAdyenAction] = useState(null)
     const [componentKey, setComponentKey] = useState(0)
@@ -135,12 +138,23 @@ const AdyenCheckoutComponent = ({
     })
 
     // Sync order number into internal state from either the basket or the fetch result
+    const resolvedOrderNo = fetchedOrderNo || basket?.c_orderNo || null
+    const internalOrderNo =
+        orderNumberState.sourceOrderNo === resolvedOrderNo
+            ? orderNumberState.currentOrderNo
+            : resolvedOrderNo
+
     useEffect(() => {
-        const resolvedOrderNo = fetchedOrderNo || basket?.c_orderNo
-        if (resolvedOrderNo && resolvedOrderNo !== internalOrderNo) {
-            setInternalOrderNo(resolvedOrderNo)
-        }
-    }, [basket?.c_orderNo, fetchedOrderNo])
+        setOrderNumberState((current) =>
+            current.sourceOrderNo === resolvedOrderNo
+                ? current
+                : {sourceOrderNo: resolvedOrderNo, currentOrderNo: resolvedOrderNo}
+        )
+    }, [resolvedOrderNo])
+
+    const setInternalOrderNo = useCallback((orderNo) => {
+        setOrderNumberState((current) => ({...current, currentOrderNo: orderNo}))
+    }, [])
 
     const setAdyenOrder = useCallback((order) => {
         adyenOrderRef.current = order
@@ -214,7 +228,7 @@ const AdyenCheckoutComponent = ({
             site,
             basket,
             adyenOrder: internalAdyenOrder,
-            orderNo: fetchedOrderNo || internalOrderNo,
+            orderNo: internalOrderNo || fetchedOrderNo,
             returnUrl,
             customerId,
             setAdyenOrder: setAdyenOrder,

--- a/packages/adyen-salesforce-pwa/lib/components/adyenCheckout.jsx
+++ b/packages/adyen-salesforce-pwa/lib/components/adyenCheckout.jsx
@@ -136,7 +136,7 @@ const AdyenCheckoutComponent = ({
 
     // Sync order number into internal state from either the basket or the fetch result
     useEffect(() => {
-        const resolvedOrderNo = basket?.c_orderNo || fetchedOrderNo
+        const resolvedOrderNo = fetchedOrderNo || basket?.c_orderNo
         if (resolvedOrderNo && resolvedOrderNo !== internalOrderNo) {
             setInternalOrderNo(resolvedOrderNo)
         }
@@ -214,7 +214,7 @@ const AdyenCheckoutComponent = ({
             site,
             basket,
             adyenOrder: internalAdyenOrder,
-            orderNo: internalOrderNo,
+            orderNo: fetchedOrderNo || internalOrderNo,
             returnUrl,
             customerId,
             setAdyenOrder: setAdyenOrder,
@@ -241,6 +241,7 @@ const AdyenCheckoutComponent = ({
         internalAdyenOrder?.orderData,
         internalAdyenOrder?.remainingAmount?.value,
         internalOrderNo,
+        fetchedOrderNo,
         returnUrl,
         customerId,
         navigate,
@@ -278,9 +279,11 @@ const AdyenCheckoutComponent = ({
             return
         }
 
-        if (orderNumberError && shouldNotifyError(ERROR_NOTIFICATION_KEYS.CHECKOUT)) {
-            console.error('Error fetching order number:', orderNumberError)
-            onError.forEach((cb) => cb(orderNumberError))
+        if (orderNumberError) {
+            if (shouldNotifyError(ERROR_NOTIFICATION_KEYS.CHECKOUT)) {
+                console.error('Error fetching order number:', orderNumberError)
+                onError.forEach((cb) => cb(orderNumberError))
+            }
             return
         }
 

--- a/packages/adyen-salesforce-pwa/lib/components/tests/adyenCheckout.test.js
+++ b/packages/adyen-salesforce-pwa/lib/components/tests/adyenCheckout.test.js
@@ -93,6 +93,7 @@ describe('AdyenCheckoutComponent', () => {
         })
 
         // Mock helpers
+        paymentMethodsConfiguration.mockReturnValue({})
         createCheckoutInstance.mockResolvedValue(mockCheckoutInstance)
         handleRedirects.mockReturnValue(false) // Default to not a redirect
         mountCheckoutComponent.mockReturnValue(mockDropinInstance)
@@ -433,6 +434,30 @@ describe('AdyenCheckoutComponent', () => {
         expect(true).toBe(true)
     })
 
+    it('should initialize checkout with the server-validated order number', async () => {
+        useAdyenOrderNumber.mockReturnValue({
+            orderNo: 'fresh-order',
+            error: null,
+            isLoading: false
+        })
+        paymentMethodsConfiguration.mockImplementation(({orderNo}) => ({orderNo}))
+        const props = {
+            ...defaultProps,
+            basket: {...defaultProps.basket, c_orderNo: 'spent-order'}
+        }
+
+        render(<AdyenCheckoutComponent {...props} />)
+
+        await waitFor(() => {
+            expect(createCheckoutInstance).toHaveBeenCalledTimes(1)
+        })
+        expect(createCheckoutInstance).toHaveBeenCalledWith(
+            expect.objectContaining({
+                paymentMethodsConfiguration: {orderNo: 'fresh-order'}
+            })
+        )
+    })
+
     it('should update orderNo when basket c_orderNo changes', async () => {
         const {rerender} = render(<AdyenCheckoutComponent {...defaultProps} />)
 
@@ -666,6 +691,25 @@ describe('AdyenCheckoutComponent', () => {
     })
 
     describe('Dual-mount error deduplication', () => {
+        it('should not initialize either instance when order number validation fails', async () => {
+            const onErrorMock = jest.fn()
+            const mockError = new Error('Order number validation failed')
+            useAdyenOrderNumber.mockReturnValue({
+                orderNo: 'unvalidated-order',
+                error: mockError,
+                isLoading: false
+            })
+            const props = {...defaultProps, onError: [onErrorMock]}
+
+            render(<AdyenCheckoutComponent {...props} />)
+            render(<AdyenCheckoutComponent {...props} />)
+
+            await waitFor(() => {
+                expect(onErrorMock).toHaveBeenCalledTimes(1)
+            })
+            expect(createCheckoutInstance).not.toHaveBeenCalled()
+        })
+
         it('should fire onError only once when two instances fail with the same error', async () => {
             const onErrorMock = jest.fn()
             const mockError = new Error('Test initialization error')

--- a/packages/adyen-salesforce-pwa/lib/components/tests/adyenCheckout.test.js
+++ b/packages/adyen-salesforce-pwa/lib/components/tests/adyenCheckout.test.js
@@ -458,6 +458,46 @@ describe('AdyenCheckoutComponent', () => {
         )
     })
 
+    it('should preserve local order number updates after server validation', async () => {
+        useAdyenOrderNumber.mockReturnValue({
+            orderNo: 'spent-order',
+            error: null,
+            isLoading: true
+        })
+        const props = {
+            ...defaultProps,
+            basket: {...defaultProps.basket, c_orderNo: 'spent-order'}
+        }
+        const {rerender} = render(<AdyenCheckoutComponent {...props} />)
+
+        useAdyenOrderNumber.mockReturnValue({
+            orderNo: 'fresh-order',
+            error: null,
+            isLoading: false
+        })
+        rerender(
+            <AdyenCheckoutComponent
+                {...props}
+                basket={{...props.basket, c_orderData: JSON.stringify({})}}
+            />
+        )
+
+        await waitFor(() => {
+            expect(paymentMethodsConfiguration).toHaveBeenLastCalledWith(
+                expect.objectContaining({orderNo: 'fresh-order'})
+            )
+        })
+
+        const {setOrderNo} = paymentMethodsConfiguration.mock.calls.at(-1)[0]
+        act(() => setOrderNo('response-order'))
+
+        await waitFor(() => {
+            expect(paymentMethodsConfiguration).toHaveBeenLastCalledWith(
+                expect.objectContaining({orderNo: 'response-order'})
+            )
+        })
+    })
+
     it('should update orderNo when basket c_orderNo changes', async () => {
         const {rerender} = render(<AdyenCheckoutComponent {...defaultProps} />)
 

--- a/packages/adyen-salesforce-pwa/lib/hooks/tests/useAdyenOrderNumber.test.js
+++ b/packages/adyen-salesforce-pwa/lib/hooks/tests/useAdyenOrderNumber.test.js
@@ -94,6 +94,27 @@ describe('useAdyenOrderNumber', () => {
         expect(result.current.orderNo).toBe('EXISTING-ORDER')
     })
 
+    it('should validate an existing order number before making it ready', async () => {
+        const {result} = renderHook(
+            () =>
+                useAdyenOrderNumber({
+                    authToken: mockAuthToken,
+                    customerId: mockCustomerId,
+                    basketId: mockBasketId,
+                    site: mockSite,
+                    existingOrderNo: 'SPENT-ORDER'
+                }),
+            {wrapper: createWrapper()}
+        )
+
+        expect(result.current.isLoading).toBe(true)
+
+        await waitFor(() => {
+            expect(result.current.isLoading).toBe(false)
+        })
+        expect(result.current.orderNo).toBe('ORDER-12345')
+    })
+
     it('should skip fetch when skip is true', () => {
         const {result} = renderHook(
             () =>

--- a/packages/adyen-salesforce-pwa/lib/hooks/useAdyenOrderNumber.js
+++ b/packages/adyen-salesforce-pwa/lib/hooks/useAdyenOrderNumber.js
@@ -41,7 +41,9 @@ const useAdyenOrderNumber = ({
     })
 
     return {
-        isLoading: query.isLoading && query.fetchStatus !== 'idle',
+        isLoading:
+            (query.isLoading && query.fetchStatus !== 'idle') ||
+            (query.isFetching && !query.isFetchedAfterMount),
         orderNo: query.data?.orderNo || null,
         error: query.error ?? null,
         refetch: query.refetch

--- a/packages/adyen-salesforce-pwa/lib/utils/constants.mjs
+++ b/packages/adyen-salesforce-pwa/lib/utils/constants.mjs
@@ -112,6 +112,7 @@ export const ERROR_MESSAGE = {
     INVALID_SHIPPING_ADDRESS: 'invalid shipping address',
     UNAUTHORIZED: 'unauthorized',
     ORDER_ALREADY_EXISTS: 'order already exists',
+    ORDER_ALREADY_PLACED: 'order already placed',
     ORDER_NOT_FOUND: 'order not found',
     ORDER_NUMBER_NOT_FOUND: 'order number not found on basket',
     PAYMENTS_DETAILS_NOT_SUCCESSFUL: 'payments details call not successful',


### PR DESCRIPTION
## Summary
- Prevent baskets from reusing order numbers that belong to placed or terminal-state SFCC orders.
- Regenerate spent order numbers during checkout initialization and reject bypass attempts with HTTP 409 before calling Adyen.
- Recover matching poisoned baskets on cancellation without deleting or clearing a newer basket.
- Keep active gift-card order-number reuse intact and avoid terminal aborts when order preflight fails before a terminal payment starts.

## Tested scenarios
- Added unit coverage for absent and `created` orders; `new`, `completed`, `cancelled`, `failed`, `failed_with_reopen`, and unknown statuses; lookup failures; matching and mismatched basket cleanup; terminal preflight; checkout validation; and dual mounts.
- Tested flows: checkout retry, gift-card, redirect, and terminal flows

**Fixed issue**: SFI-1701