### PR TITLE
[SFI-1702] Create order before express payment

### DIFF
--- a/packages/adyen-salesforce-pwa/lib/api/controllers/payment-cancel-express.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/payment-cancel-express.js
@@ -1,5 +1,6 @@
 import Logger from '../models/logger'
 import {ERROR_MESSAGE} from '../../utils/constants.mjs'
+import {AdyenError} from '../models/AdyenError'
 import {revertCheckoutStateForExpress} from '../helpers/paymentsHelper.js'
 import {failOrderAndReopenBasket} from '../helpers/orderHelper.js'
 
@@ -17,7 +18,10 @@ async function paymentCancelExpress(req, res, next) {
     Logger.info('paymentCancelExpress', 'start')
     try {
         const {adyen: adyenContext} = res.locals
-        const orderNo = req.body?.orderNo || adyenContext?.basket?.c_orderNo
+        if (!adyenContext) {
+            throw new AdyenError(ERROR_MESSAGE.ADYEN_CONTEXT_NOT_FOUND, 500)
+        }
+        const orderNo = req.body?.orderNo || adyenContext.basket?.c_orderNo
         const isTemporaryBasket = req.body?.isTemporaryBasket === true
 
         if (orderNo) {

--- a/packages/adyen-salesforce-pwa/lib/api/controllers/payment-cancel-express.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/payment-cancel-express.js
@@ -1,12 +1,15 @@
 import Logger from '../models/logger'
+import {ERROR_MESSAGE} from '../../utils/constants.mjs'
 import {revertCheckoutStateForExpress} from '../helpers/paymentsHelper.js'
+import {failOrderAndReopenBasket} from '../helpers/orderHelper.js'
 
 /**
  * An Express middleware that handles the cancellation of an express payment.
- * It cleans up the basket, removes shipping method and shipping address.
+ * When an SFCC order was already created for the express payment, the order is failed and the
+ * basket reopened. Otherwise it just cleans up the basket, removing shipping method and address.
  *
  * @param {object} req - The Express request object.
- * @param {object} res - The Express response object (not used).
+ * @param {object} res - The Express response object.
  * @param {Function} next - The Express next middleware function.
  * @returns {Promise<void>}
  */
@@ -14,6 +17,29 @@ async function paymentCancelExpress(req, res, next) {
     Logger.info('paymentCancelExpress', 'start')
     try {
         const {adyen: adyenContext} = res.locals
+        const orderNo = req.body?.orderNo || adyenContext?.basket?.c_orderNo
+        const isTemporaryBasket = req.body?.isTemporaryBasket === true
+
+        if (orderNo) {
+            try {
+                const newBasketId = await failOrderAndReopenBasket(adyenContext, orderNo, {
+                    reopenBasket: !isTemporaryBasket,
+                    removeShippingAddress: true
+                })
+                res.locals.response = {newBasketId}
+                return next()
+            } catch (err) {
+                // The shopper commonly dismisses the payment sheet before an order exists;
+                // fall back to reverting the basket in that case only.
+                if (err.message !== ERROR_MESSAGE.ORDER_NOT_FOUND) {
+                    throw err
+                }
+                Logger.info(
+                    'paymentCancelExpress',
+                    `no order ${orderNo} to fail — reverting basket state`
+                )
+            }
+        }
 
         await revertCheckoutStateForExpress(adyenContext, 'paymentCancelExpress')
         res.locals.response = {}

--- a/packages/adyen-salesforce-pwa/lib/api/controllers/payments-details.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/payments-details.js
@@ -17,13 +17,19 @@ import {createIdempotencyKey} from '../utils/paymentUtils'
 
 /**
  * Handles errors that occur during the payment details submission process.
- * If an order was pre-created before the paymentsDetails call, fails it and reopens the basket.
- * Otherwise reverts basket state.
+ * If an order was already created, fails it and reopens the basket. Otherwise reverts basket state,
+ * falling back to the shopper's open order when the basket was already consumed.
  * @param {object} res - The Express response object.
- * @param {string|null} orderNo - The order number if an order was pre-created.
+ * @param {string|null} orderNo - The order number if an order already exists for this payment.
+ * @param {object} [options] - Failure handling options.
+ * @param {boolean} [options.isTemporaryBasket=false] - True when the order was created from a
+ * temporary (PDP express) basket, in which case the shopper's real cart must not be reopened.
+ * @param {boolean} [options.removeShippingAddress=false] - True for express flows, where the
+ * shipping address must be cleared so the express button re-mounts on a clean basket.
  * @returns {Promise<string|null>} The new basket ID if the order was failed and basket reopened.
  */
-async function handlePaymentDetailsError(res, orderNo) {
+async function handlePaymentDetailsError(res, orderNo, options = {}) {
+    const {isTemporaryBasket = false, removeShippingAddress = false} = options
     try {
         Logger.info('handlePaymentDetailsError', 'start')
         const adyenContext = res.locals.adyen
@@ -47,7 +53,10 @@ async function handlePaymentDetailsError(res, orderNo) {
         }
 
         if (resolvedOrderNo) {
-            return await failOrderAndReopenBasket(adyenContext, resolvedOrderNo)
+            return await failOrderAndReopenBasket(adyenContext, resolvedOrderNo, {
+                reopenBasket: !isTemporaryBasket,
+                removeShippingAddress
+            })
         }
     } catch (err) {
         Logger.error('handlePaymentDetailsError', err.stack)
@@ -59,18 +68,18 @@ async function handlePaymentDetailsError(res, orderNo) {
  * An Express middleware that handles the /payments/details request from the client.
  * This is used for handling additional actions required by 3D Secure, redirects, etc.
  * If the details call fails, the order is failed and the basket is reopened.
+ * Express flows send `orderNo` because the order was already created in the /payments step; the
+ * order is still verified against the shopper before it can be failed.
  * @param {object} req - The Express request object.
  * @param {object} res - The Express response object.
  * @param {Function} next - The Express next middleware function.
  * @returns {Promise<void>}
  */
 async function sendPaymentDetails(req, res, next) {
+    const {data, orderNo: clientOrderNo, isTemporaryBasket = false} = req.body || {}
     let preCreatedOrderNo = null
     try {
         Logger.info('sendPaymentDetails', 'start')
-        const {
-            body: {data}
-        } = req
         const {adyen: adyenContext} = res.locals
         if (!adyenContext) {
             throw new AdyenError(ERROR_MESSAGE.ADYEN_CONTEXT_NOT_FOUND, 500)
@@ -82,7 +91,13 @@ async function sendPaymentDetails(req, res, next) {
         const amount = basket.c_amount ? JSON.parse(basket.c_amount) : ''
         const paymentMethod = basket.c_paymentMethod ? JSON.parse(basket.c_paymentMethod) : ''
 
-        if (!hasBasket || isStandardRedirectReturn) {
+        if (clientOrderNo) {
+            preCreatedOrderNo = clientOrderNo
+            Logger.info(
+                'sendPaymentDetails',
+                `order already created in payments step: ${preCreatedOrderNo}`
+            )
+        } else if (!hasBasket || isStandardRedirectReturn) {
             Logger.info(
                 'sendPaymentDetails',
                 `standard redirect return — order pre-created in payments step (hasBasket: ${hasBasket})`
@@ -105,7 +120,7 @@ async function sendPaymentDetails(req, res, next) {
 
         const resolvedOrderNo = response?.merchantReference || preCreatedOrderNo
 
-        if ((!hasBasket || isStandardRedirectReturn) && resolvedOrderNo) {
+        if (!clientOrderNo && (!hasBasket || isStandardRedirectReturn) && resolvedOrderNo) {
             preCreatedOrderNo = resolvedOrderNo
             Logger.info('sendPaymentDetails', `resolved pre-created order: ${preCreatedOrderNo}`)
         }
@@ -156,7 +171,11 @@ async function sendPaymentDetails(req, res, next) {
         return next()
     } catch (err) {
         Logger.error('sendPaymentDetails', err.stack)
-        const newBasketId = await handlePaymentDetailsError(res, preCreatedOrderNo)
+        const newBasketId = await handlePaymentDetailsError(
+            res,
+            preCreatedOrderNo || clientOrderNo,
+            {isTemporaryBasket, removeShippingAddress: !!clientOrderNo}
+        )
         if (newBasketId) {
             err.newBasketId = newBasketId
         }

--- a/packages/adyen-salesforce-pwa/lib/api/controllers/payments.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/payments.js
@@ -36,6 +36,9 @@ async function handlePaymentError(res, orderNo, options = {}) {
     try {
         Logger.info('handlePaymentError', 'start')
         const adyenContext = res.locals.adyen
+        if (!adyenContext) {
+            return null
+        }
         if (orderNo) {
             return await failOrderAndReopenBasket(adyenContext, orderNo, {
                 reopenBasket: !isTemporaryBasket,

--- a/packages/adyen-salesforce-pwa/lib/api/controllers/payments.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/payments.js
@@ -1,4 +1,4 @@
-import {ERROR_MESSAGE, PAYMENT_METHOD_TYPES} from '../../utils/constants.mjs'
+import {ERROR_MESSAGE} from '../../utils/constants.mjs'
 import AdyenClientProvider from '../models/adyenClientProvider'
 import Logger from '../models/logger'
 import {AdyenError} from '../models/AdyenError'
@@ -6,6 +6,7 @@ import {
     createCheckoutResponse,
     createPaymentRequestObject,
     revertCheckoutState,
+    shouldCreateOrderBeforePayment,
     validateBasketPayments,
     isApplePayExpress,
     isGooglePayExpress
@@ -18,31 +19,28 @@ import {
 import {createIdempotencyKey} from '../utils/paymentUtils'
 
 /**
- * Returns true if the payment is a standard (non-express, non-gift-card) payment
- * for which the SFCC order should be created before calling Adyen /payments.
- * @param {object} data - The payment state data from the client.
- * @returns {boolean}
- */
-function isStandardPayment(data) {
-    const isExpress = data?.paymentMethod?.subtype === 'express'
-    const isGiftCard = data?.paymentMethod?.type === PAYMENT_METHOD_TYPES.GIFT_CARD
-    return !isExpress && !isGiftCard
-}
-
-/**
  * Handles errors that occur during the payment process.
- * For standard payments where an order was already created, fails the order and reopens the basket.
+ * When an order was already created, fails the order and reopens the basket.
  * For other flows, reverts basket state.
  * @param {object} res - The Express response object.
  * @param {string|null} orderNo - The order number if an order was created before the payment call.
+ * @param {object} [options] - Failure handling options.
+ * @param {boolean} [options.isTemporaryBasket=false] - True when the order was created from a
+ * temporary (PDP express) basket, in which case the shopper's real cart must not be reopened.
+ * @param {boolean} [options.isExpressOrder=false] - True for Apple Pay / Google Pay express, where
+ * the shipping address must be cleared so the express button re-mounts on a clean basket.
  * @returns {Promise<string|null>} The new basket ID if the order was failed and basket reopened.
  */
-async function handlePaymentError(res, orderNo) {
+async function handlePaymentError(res, orderNo, options = {}) {
+    const {isTemporaryBasket = false, isExpressOrder = false} = options
     try {
         Logger.info('handlePaymentError', 'start')
         const adyenContext = res.locals.adyen
         if (orderNo) {
-            return await failOrderAndReopenBasket(adyenContext, orderNo)
+            return await failOrderAndReopenBasket(adyenContext, orderNo, {
+                reopenBasket: !isTemporaryBasket,
+                removeShippingAddress: isExpressOrder
+            })
         }
         await revertCheckoutState(adyenContext, 'sendPayments')
     } catch (err) {
@@ -55,7 +53,7 @@ async function handlePaymentError(res, orderNo) {
  * An Express middleware that handles the /payments request from the client.
  * It orchestrates the payment process by creating a payment request,
  * calling the Adyen API, and handling the response.
- * For standard (non-express, non-gift-card) payments, the SFCC order is created
+ * For every payment except PayPal express and gift cards, the SFCC order is created
  * BEFORE calling Adyen /payments to prevent orphan payments. If the payment fails,
  * the order is failed and the basket is reopened.
  * @param {object} req - The Express request object.
@@ -65,6 +63,8 @@ async function handlePaymentError(res, orderNo) {
  */
 async function sendPayments(req, res, next) {
     let preCreatedOrderNo = null
+    let isTemporaryBasket = false
+    let isExpressOrder = false
     try {
         Logger.info('sendPayments', 'start')
         const {
@@ -86,7 +86,9 @@ async function sendPayments(req, res, next) {
             paymentRequest.paymentMethod
         )
 
-        if (isStandardPayment(data)) {
+        if (shouldCreateOrderBeforePayment(data)) {
+            isTemporaryBasket = adyenContext.basket?.temporaryBasket === true
+            isExpressOrder = isApplePayExpress(data) || isGooglePayExpress(data)
             await adyenContext.basketService.addPaymentInstrument(
                 paymentRequest?.amount,
                 paymentRequest?.paymentMethod,
@@ -233,7 +235,10 @@ async function sendPayments(req, res, next) {
             })
         }
 
-        const newBasketId = await handlePaymentError(res, preCreatedOrderNo)
+        const newBasketId = await handlePaymentError(res, preCreatedOrderNo, {
+            isTemporaryBasket,
+            isExpressOrder
+        })
         if (newBasketId) {
             err.newBasketId = newBasketId
         }

--- a/packages/adyen-salesforce-pwa/lib/api/controllers/tests/payment-cancel-express.test.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/tests/payment-cancel-express.test.js
@@ -118,6 +118,22 @@ describe('paymentCancelExpress Controller', () => {
         expect(next).toHaveBeenCalledWith()
     })
 
+    it('should throw an AdyenError when the adyen context is missing', async () => {
+        req.body = {orderNo: 'order-6'}
+        res.locals = {}
+
+        await paymentCancelExpress(req, res, next)
+
+        expect(failOrderAndReopenBasket).not.toHaveBeenCalled()
+        expect(revertCheckoutStateForExpress).not.toHaveBeenCalled()
+        expect(next).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: ERROR_MESSAGE.ADYEN_CONTEXT_NOT_FOUND,
+                statusCode: 500
+            })
+        )
+    })
+
     it('should propagate errors other than order not found', async () => {
         req.body = {orderNo: 'order-5'}
         const invalidOrderError = new AdyenError(ERROR_MESSAGE.INVALID_ORDER, 404)

--- a/packages/adyen-salesforce-pwa/lib/api/controllers/tests/payment-cancel-express.test.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/tests/payment-cancel-express.test.js
@@ -1,10 +1,16 @@
 import paymentCancelExpress from '../payment-cancel-express'
 import Logger from '../../models/logger'
 import {revertCheckoutStateForExpress} from '../../helpers/paymentsHelper.js'
+import {failOrderAndReopenBasket} from '../../helpers/orderHelper.js'
+import {AdyenError} from '../../models/AdyenError'
+import {ERROR_MESSAGE} from '../../../utils/constants.mjs'
 
 jest.mock('../../models/logger')
 jest.mock('../../helpers/paymentsHelper.js', () => ({
     revertCheckoutStateForExpress: jest.fn()
+}))
+jest.mock('../../helpers/orderHelper.js', () => ({
+    failOrderAndReopenBasket: jest.fn()
 }))
 
 describe('paymentCancelExpress Controller', () => {
@@ -13,7 +19,7 @@ describe('paymentCancelExpress Controller', () => {
     beforeEach(() => {
         jest.clearAllMocks()
 
-        req = {}
+        req = {body: {}}
         res = {
             locals: {
                 adyen: {}
@@ -28,6 +34,7 @@ describe('paymentCancelExpress Controller', () => {
         await paymentCancelExpress(req, res, next)
 
         expect(Logger.info).toHaveBeenCalledWith('paymentCancelExpress', 'start')
+        expect(failOrderAndReopenBasket).not.toHaveBeenCalled()
         expect(revertCheckoutStateForExpress).toHaveBeenCalledWith(
             res.locals.adyen,
             'paymentCancelExpress'
@@ -51,5 +58,74 @@ describe('paymentCancelExpress Controller', () => {
         )
         expect(Logger.error).toHaveBeenCalledWith('paymentCancelExpress', mockError.stack)
         expect(next).toHaveBeenCalledWith(mockError)
+    })
+
+    it('should fail the order from the request body and return the new basket id', async () => {
+        req.body = {orderNo: 'order-1'}
+        failOrderAndReopenBasket.mockResolvedValue('newBasket-1')
+
+        await paymentCancelExpress(req, res, next)
+
+        expect(failOrderAndReopenBasket).toHaveBeenCalledWith(res.locals.adyen, 'order-1', {
+            reopenBasket: true,
+            removeShippingAddress: true
+        })
+        expect(revertCheckoutStateForExpress).not.toHaveBeenCalled()
+        expect(res.locals.response).toEqual({newBasketId: 'newBasket-1'})
+        expect(next).toHaveBeenCalledWith()
+    })
+
+    it('should fall back to c_orderNo on the basket', async () => {
+        res.locals.adyen = {basket: {basketId: 'b1', c_orderNo: 'order-2'}}
+        failOrderAndReopenBasket.mockResolvedValue('newBasket-2')
+
+        await paymentCancelExpress(req, res, next)
+
+        expect(failOrderAndReopenBasket).toHaveBeenCalledWith(res.locals.adyen, 'order-2', {
+            reopenBasket: true,
+            removeShippingAddress: true
+        })
+        expect(res.locals.response).toEqual({newBasketId: 'newBasket-2'})
+    })
+
+    it('should not reopen the basket for a temporary (PDP) express basket', async () => {
+        req.body = {orderNo: 'order-3', isTemporaryBasket: true}
+        failOrderAndReopenBasket.mockResolvedValue(null)
+
+        await paymentCancelExpress(req, res, next)
+
+        expect(failOrderAndReopenBasket).toHaveBeenCalledWith(res.locals.adyen, 'order-3', {
+            reopenBasket: false,
+            removeShippingAddress: true
+        })
+        expect(res.locals.response).toEqual({newBasketId: null})
+    })
+
+    it('should revert the basket when the order does not exist yet', async () => {
+        req.body = {orderNo: 'order-4'}
+        failOrderAndReopenBasket.mockRejectedValue(
+            new AdyenError(ERROR_MESSAGE.ORDER_NOT_FOUND, 404)
+        )
+        revertCheckoutStateForExpress.mockResolvedValue(undefined)
+
+        await paymentCancelExpress(req, res, next)
+
+        expect(revertCheckoutStateForExpress).toHaveBeenCalledWith(
+            res.locals.adyen,
+            'paymentCancelExpress'
+        )
+        expect(res.locals.response).toEqual({})
+        expect(next).toHaveBeenCalledWith()
+    })
+
+    it('should propagate errors other than order not found', async () => {
+        req.body = {orderNo: 'order-5'}
+        const invalidOrderError = new AdyenError(ERROR_MESSAGE.INVALID_ORDER, 404)
+        failOrderAndReopenBasket.mockRejectedValue(invalidOrderError)
+
+        await paymentCancelExpress(req, res, next)
+
+        expect(revertCheckoutStateForExpress).not.toHaveBeenCalled()
+        expect(next).toHaveBeenCalledWith(invalidOrderError)
     })
 })

--- a/packages/adyen-salesforce-pwa/lib/api/controllers/tests/payments-details.test.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/tests/payments-details.test.js
@@ -107,7 +107,11 @@ describe('payments details controller', () => {
 
         await sendPaymentDetails(req, res, next)
 
-        expect(orderHelper.failOrderAndReopenBasket).toHaveBeenCalled()
+        // Standard flow keeps the shipping address on the reopened basket
+        expect(orderHelper.failOrderAndReopenBasket).toHaveBeenCalledWith(res.locals.adyen, '123', {
+            reopenBasket: true,
+            removeShippingAddress: false
+        })
         expect(paymentsHelper.revertCheckoutState).not.toHaveBeenCalled()
         const err = next.mock.calls[0][0]
         expect(err).toBeInstanceOf(AdyenError)
@@ -172,6 +176,63 @@ describe('payments details controller', () => {
         expect(res.locals.response.isFinal).toBe(false)
         expect(res.locals.response.isSuccessful).toBe(true)
         expect(next).toHaveBeenCalledWith()
+    })
+
+    describe('express flow with a client-supplied orderNo', () => {
+        beforeEach(() => {
+            req.body.orderNo = 'express-order-1'
+        })
+
+        it('skips order creation and patches the payment instrument on the supplied order', async () => {
+            mockPaymentsDetails.mockResolvedValue({
+                resultCode: RESULT_CODES.AUTHORISED,
+                pspReference: 'psp-gp-3ds'
+            })
+
+            await sendPaymentDetails(req, res, next)
+
+            expect(paymentsHelper.validateBasketPayments).not.toHaveBeenCalled()
+            expect(res.locals.adyen.basketService.addPaymentInstrument).not.toHaveBeenCalled()
+            expect(orderHelper.createOrderUsingOrderNo).not.toHaveBeenCalled()
+            expect(orderHelper.updateOrderPaymentInstrument).toHaveBeenCalledWith(
+                'express-order-1',
+                'RefArch',
+                'psp-gp-3ds',
+                {pspReference: 'psp-gp-3ds', donationToken: undefined}
+            )
+            expect(res.locals.response.merchantReference).toBe('express-order-1')
+            expect(next).toHaveBeenCalledWith()
+        })
+
+        it('fails the supplied order and clears the shipping address when 3DS is refused', async () => {
+            mockPaymentsDetails.mockResolvedValue({resultCode: RESULT_CODES.REFUSED})
+            orderHelper.failOrderAndReopenBasket.mockResolvedValue('newBasketExpress')
+
+            await sendPaymentDetails(req, res, next)
+
+            expect(orderHelper.failOrderAndReopenBasket).toHaveBeenCalledWith(
+                res.locals.adyen,
+                'express-order-1',
+                {reopenBasket: true, removeShippingAddress: true}
+            )
+            expect(paymentsHelper.revertCheckoutState).not.toHaveBeenCalled()
+            expect(next.mock.calls[0][0].newBasketId).toBe('newBasketExpress')
+        })
+
+        it('does not reopen the basket when the order came from a temporary basket', async () => {
+            req.body.isTemporaryBasket = true
+            mockPaymentsDetails.mockRejectedValue(new Error('Network timeout'))
+            orderHelper.failOrderAndReopenBasket.mockResolvedValue(null)
+
+            await sendPaymentDetails(req, res, next)
+
+            expect(orderHelper.failOrderAndReopenBasket).toHaveBeenCalledWith(
+                res.locals.adyen,
+                'express-order-1',
+                {reopenBasket: false, removeShippingAddress: true}
+            )
+            expect(next.mock.calls[0][0].newBasketId).toBeUndefined()
+        })
     })
 
     describe('no-basket (standard 3DS) flow', () => {

--- a/packages/adyen-salesforce-pwa/lib/api/controllers/tests/payments.test.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/tests/payments.test.js
@@ -1,5 +1,5 @@
 import sendPayments from '../payments'
-import {RESULT_CODES} from '../../../utils/constants.mjs'
+import {ERROR_MESSAGE, RESULT_CODES} from '../../../utils/constants.mjs'
 import {AdyenError} from '../../models/AdyenError'
 import * as orderHelper from '../../helpers/orderHelper.js'
 import * as paymentsHelper from '../../helpers/paymentsHelper.js'
@@ -365,6 +365,18 @@ describe('payments controller', () => {
         res.locals.adyen = undefined
         await sendPayments(req, res, next)
         expect(next).toHaveBeenCalledWith(expect.any(AdyenError))
+    })
+
+    it('skips basket recovery when adyenContext is not set', async () => {
+        res.locals.adyen = undefined
+
+        await sendPayments(req, res, next)
+
+        expect(orderHelper.failOrderAndReopenBasket).not.toHaveBeenCalled()
+        expect(paymentsHelper.revertCheckoutState).not.toHaveBeenCalled()
+        const err = next.mock.calls[0][0]
+        expect(err.message).toBe(ERROR_MESSAGE.ADYEN_CONTEXT_NOT_FOUND)
+        expect(err.newBasketId).toBeUndefined()
     })
 
     it('calls addShopperData for Apple Pay Express', async () => {

--- a/packages/adyen-salesforce-pwa/lib/api/controllers/tests/payments.test.js
+++ b/packages/adyen-salesforce-pwa/lib/api/controllers/tests/payments.test.js
@@ -56,6 +56,15 @@ jest.mock('../../helpers/paymentsHelper.js', () => {
         }),
         revertCheckoutState: jest.fn(),
         validateBasketPayments: jest.fn(),
+        shouldCreateOrderBeforePayment: jest.fn((data) => {
+            if (data?.paymentMethod?.type === 'giftcard') {
+                return false
+            }
+            if (data?.paymentMethod?.subtype !== 'express') {
+                return true
+            }
+            return ['applepay', 'googlepay'].includes(data?.paymentMethod?.type)
+        }),
         isApplePayExpress: jest.fn(
             (data) =>
                 data?.paymentMethod?.type === 'applepay' &&
@@ -237,26 +246,79 @@ describe('payments controller', () => {
         expect(err.newBasketId).toBe('newBasket456')
     })
 
-    it('express payment: updates basket and creates order on AUTHORISED', async () => {
-        req.body.data = {paymentMethod: {type: 'applepay', subtype: 'express'}}
+    it.each([['applepay'], ['googlepay']])(
+        '%s express: pre-creates order and skips basket update on AUTHORISED',
+        async (type) => {
+            req.body.data = {paymentMethod: {type, subtype: 'express'}}
+            res.locals.adyen.basketService.addShopperData = jest.fn()
+            mockPayments.mockResolvedValue({
+                resultCode: RESULT_CODES.AUTHORISED,
+                merchantReference: 'ref123',
+                pspReference: 'psp456'
+            })
+
+            await sendPayments(req, res, next)
+
+            expect(res.locals.adyen.basketService.addPaymentInstrument).toHaveBeenCalled()
+            expect(orderHelper.createOrderUsingOrderNo).toHaveBeenCalledTimes(1)
+            // basket was consumed by order creation — must NOT attempt basket update
+            expect(res.locals.adyen.basketService.update).not.toHaveBeenCalled()
+            expect(orderHelper.updateOrderPaymentInstrument).toHaveBeenCalledWith(
+                '123',
+                'RefArch',
+                'psp456',
+                {
+                    pspReference: 'psp456',
+                    cardInstallments: undefined,
+                    donationToken: undefined
+                }
+            )
+            expect(res.locals.response.isSuccessful).toBe(true)
+            expect(next).toHaveBeenCalledWith()
+        }
+    )
+
+    it('googlepay express: fails order and reopens basket on refused payment', async () => {
+        req.body.data = {paymentMethod: {type: 'googlepay', subtype: 'express'}}
         res.locals.adyen.basketService.addShopperData = jest.fn()
         mockPayments.mockResolvedValue({
-            resultCode: RESULT_CODES.AUTHORISED,
-            merchantReference: 'ref123',
-            pspReference: 'psp456'
+            resultCode: RESULT_CODES.REFUSED,
+            merchantReference: 'ref123'
         })
+        orderHelper.failOrderAndReopenBasket.mockResolvedValue('newBasket456')
 
         await sendPayments(req, res, next)
 
-        // no order pre-creation for express
-        expect(orderHelper.createOrderUsingOrderNo).toHaveBeenCalledTimes(1)
-        // basket still alive — update should be called
-        expect(res.locals.adyen.basketService.update).toHaveBeenCalled()
-        expect(res.locals.response.isSuccessful).toBe(true)
-        expect(next).toHaveBeenCalledWith()
+        expect(orderHelper.failOrderAndReopenBasket).toHaveBeenCalledWith(res.locals.adyen, '123', {
+            reopenBasket: true,
+            removeShippingAddress: true
+        })
+        expect(paymentsHelper.revertCheckoutState).not.toHaveBeenCalled()
+        const err = next.mock.calls[0][0]
+        expect(err.newBasketId).toBe('newBasket456')
     })
 
-    it('express payment: updates basket with action on redirect', async () => {
+    it('applepay express on a temporary basket: fails order without reopening the basket', async () => {
+        req.body.data = {paymentMethod: {type: 'applepay', subtype: 'express'}}
+        res.locals.adyen.basket = {...mockBasket, temporaryBasket: true}
+        res.locals.adyen.basketService.addShopperData = jest.fn()
+        mockPayments.mockResolvedValue({
+            resultCode: RESULT_CODES.REFUSED,
+            merchantReference: 'ref123'
+        })
+        orderHelper.failOrderAndReopenBasket.mockResolvedValue(null)
+
+        await sendPayments(req, res, next)
+
+        expect(orderHelper.failOrderAndReopenBasket).toHaveBeenCalledWith(res.locals.adyen, '123', {
+            reopenBasket: false,
+            removeShippingAddress: true
+        })
+        const err = next.mock.calls[0][0]
+        expect(err.newBasketId).toBeUndefined()
+    })
+
+    it('paypal express: does not pre-create the order and updates basket with action on redirect', async () => {
         req.body.data = {paymentMethod: {type: 'paypal', subtype: 'express'}}
         res.locals.adyen.basketService.addShopperData = jest.fn()
         const mockAction = {type: 'redirect'}
@@ -267,6 +329,7 @@ describe('payments controller', () => {
 
         await sendPayments(req, res, next)
 
+        expect(orderHelper.createOrderUsingOrderNo).not.toHaveBeenCalled()
         // no pre-created order — basket update should be called
         expect(res.locals.adyen.basketService.update).toHaveBeenCalled()
         expect(res.locals.response).toEqual({
@@ -278,6 +341,24 @@ describe('payments controller', () => {
             resultCode: RESULT_CODES.REDIRECT_SHOPPER
         })
         expect(next).toHaveBeenCalledWith()
+    })
+
+    it('paypal express: reverts checkout state on refused payment', async () => {
+        req.body.data = {paymentMethod: {type: 'paypal', subtype: 'express'}}
+        res.locals.adyen.basketService.addShopperData = jest.fn()
+        mockPayments.mockResolvedValue({
+            resultCode: RESULT_CODES.REFUSED,
+            merchantReference: 'ref123'
+        })
+
+        await sendPayments(req, res, next)
+
+        expect(orderHelper.failOrderAndReopenBasket).not.toHaveBeenCalled()
+        expect(paymentsHelper.revertCheckoutState).toHaveBeenCalledWith(
+            res.locals.adyen,
+            'sendPayments'
+        )
+        expect(next).toHaveBeenCalledWith(expect.any(AdyenError))
     })
 
     it('throws when adyenContext is not set', async () => {

--- a/packages/adyen-salesforce-pwa/lib/api/helpers/orderHelper.js
+++ b/packages/adyen-salesforce-pwa/lib/api/helpers/orderHelper.js
@@ -60,18 +60,25 @@ export function createShopperOrderClient(authorization, siteId) {
 }
 
 /**
- * Fails an SFCC order and triggers the reopening of the associated basket.
+ * Fails an SFCC order and, by default, triggers the reopening of the associated basket.
  * It validates that the order belongs to the customer, deletes all existing shopper baskets,
  * then updates the order status to failed_with_reopen so SFCC creates a clean new basket.
  * Resolves the new basket ID from the Location header if present, otherwise falls back to
  * fetching the shopper's current basket. Clears c_orderNo and payment instruments on the new basket.
  * @param {object} adyenContext - The request context from `res.locals.adyen`.
  * @param {string} orderNo - The number of the order to fail.
+ * @param {object} [options] - Reopen behaviour.
+ * @param {boolean} [options.reopenBasket=true] - When false, the order is simply failed and no
+ * basket is deleted or reopened. Used for orders created from a temporary (PDP express) basket,
+ * where the shopper's real cart must survive.
+ * @param {boolean} [options.removeShippingAddress=false] - When true, the shipping address is
+ * cleared on the reopened basket, resetting express checkout state.
  * @returns {Promise<string|null>} The new basket ID, or null if it could not be resolved.
  * @throws {AdyenError} If the order is not found or does not belong to the customer.
  */
-export async function failOrderAndReopenBasket(adyenContext, orderNo) {
+export async function failOrderAndReopenBasket(adyenContext, orderNo, options = {}) {
     Logger.info('failOrderAndReopenBasket', 'start')
+    const {reopenBasket = true, removeShippingAddress = false} = options
     const {authorization, customerId, siteId} = adyenContext
     const shopperOrders = createShopperOrderClient(authorization, siteId)
 
@@ -86,28 +93,36 @@ export async function failOrderAndReopenBasket(adyenContext, orderNo) {
     if (order?.customerInfo?.customerId !== customerId) {
         throw new AdyenError(ERROR_MESSAGE.INVALID_ORDER, 404)
     }
-    try {
-        const shopperBaskets = createShopperBasketsClient(authorization, siteId)
-        const {baskets} = await getCustomerBaskets(authorization, customerId, siteId)
-        if (baskets?.length) {
-            await Promise.all(
-                baskets.map((b) =>
-                    shopperBaskets.deleteBasket({parameters: {basketId: b.basketId}})
+    if (reopenBasket) {
+        try {
+            const shopperBaskets = createShopperBasketsClient(authorization, siteId)
+            const {baskets} = await getCustomerBaskets(authorization, customerId, siteId)
+            if (baskets?.length) {
+                await Promise.all(
+                    baskets.map((b) =>
+                        shopperBaskets.deleteBasket({parameters: {basketId: b.basketId}})
+                    )
                 )
+            }
+        } catch (err) {
+            Logger.error(
+                'failOrderAndReopenBasket',
+                `Failed to delete existing baskets: ${err.message}`
             )
         }
-    } catch (err) {
-        Logger.error(
-            'failOrderAndReopenBasket',
-            `Failed to delete existing baskets: ${err.message}`
-        )
     }
 
     const orderApi = new OrderApiClient(siteId)
     const response = await orderApi.updateOrderStatus(
         order.orderNo,
-        ORDER.ORDER_STATUS_FAILED_REOPEN
+        reopenBasket ? ORDER.ORDER_STATUS_FAILED_REOPEN : ORDER.ORDER_STATUS_FAILED
     )
+
+    if (!reopenBasket) {
+        Logger.info('failOrderAndReopenBasket', 'order failed without reopening a basket')
+        return null
+    }
+
     const location = response?.headers?.get('Location')
     const match = location?.match(/baskets\/([^?/]+)/)
     let newBasketId = match ? match[1] : null
@@ -121,6 +136,9 @@ export async function failOrderAndReopenBasket(adyenContext, orderNo) {
         const tempRes = {locals: {adyen: tempContext}}
         tempContext.basketService = new BasketService(tempContext, tempRes)
         await cleanupReopenedBasket(tempContext, 'failOrderAndReopenBasket')
+        if (removeShippingAddress) {
+            await tempContext.basketService.removeShippingAddress()
+        }
     } catch (err) {
         Logger.error('failOrderAndReopenBasket', `Failed to clean up new basket: ${err.message}`)
     }

--- a/packages/adyen-salesforce-pwa/lib/api/helpers/paymentsHelper.js
+++ b/packages/adyen-salesforce-pwa/lib/api/helpers/paymentsHelper.js
@@ -111,8 +111,9 @@ export function createCheckoutResponse(response, orderNumber) {
 /**
  * Validates that the sum of all payment instruments and the current payment request amount
  * equals the basket's expected total amount.
- * For express payments (PayPal, Apple Pay), validates against the payment request amount
- * since tax may not be calculated yet. For standard payments, validates against order total.
+ * PayPal express is built from the net product amount (no tax, no shipping), so its request
+ * amount is taken as the expected total and the comparison is skipped. Every other payment,
+ * including Apple Pay and Google Pay express, is validated against the basket order total.
  * @param {object} adyenContext - The request context from `res.locals.adyen`.
  * @param {object} [amount] - The Adyen payment request amount with value and currency.
  * @param {object} [paymentMethod] - The Adyen payment request paymentMethod.
@@ -124,16 +125,14 @@ export async function validateBasketPayments(adyenContext, amount, paymentMethod
     const isPartialPayment = !!adyenOrderData?.orderData
     const remainingAmountValue = adyenOrderData?.remainingAmount?.value ?? 0
     const isGiftCardPayment = paymentMethod?.type === PAYMENT_METHOD_TYPES.GIFT_CARD
-    const isExpressPayment = paymentMethod?.subtype === 'express'
+    const isPayPalExpressPayment = isPayPalExpress({paymentMethod})
 
     // Validate currency match
     if (amount?.currency && amount.currency !== basket.currency) {
         throw new AdyenError('Currency mismatch between payment and basket', 409)
     }
 
-    // For express payments, use the payment request amount as the expected total
-    // since tax isn't calculated yet. For standard payments, use order total.
-    const expectedBasketTotal = isExpressPayment
+    const expectedBasketTotal = isPayPalExpressPayment
         ? amount?.value
         : getCurrencyValueForApi(basket.orderTotal, basket.currency)
 
@@ -164,9 +163,9 @@ export async function validateBasketPayments(adyenContext, amount, paymentMethod
 
     const finalAmount = existingInstrumentsTotalInMinorUnits + (amount?.value ?? 0)
 
-    // For express payments, skip validation since amount is based on productTotal
-    // and will be validated after tax calculation
-    if (isExpressPayment) {
+    // PayPal express is submitted with the net product amount, so it can only be validated
+    // once tax and shipping have been calculated on the basket.
+    if (isPayPalExpressPayment) {
         return
     }
 
@@ -233,6 +232,8 @@ export async function revertCheckoutState(adyenContext, stepName) {
  * Handles the cleanup process for a failed express payment.
  * It resets the basket's Adyen-related custom attributes, removes all payment instruments,
  * removes shipping method and shipping address from the basket.
+ * Does nothing when no basket is resolved, so a fallback basket created after the real one was
+ * consumed into an order is left untouched.
  * @param {object} adyenContext - The request context from `res.locals.adyen`.
  * @param {string} stepName - The name of the controller step for logging purposes (e.g., 'paymentCancelExpress').
  */
@@ -240,6 +241,11 @@ export async function revertCheckoutStateForExpress(adyenContext, stepName) {
     if (!adyenContext) {
         const errorMessage = `${ERROR_MESSAGE.ADYEN_CONTEXT_NOT_FOUND} in ${stepName}`
         throw new AdyenError(errorMessage, 500)
+    }
+
+    if (!adyenContext.basket?.basketId) {
+        Logger.info(stepName, 'revertCheckoutStateForExpress skipped — no basket to revert')
+        return
     }
 
     await _cleanupBasket(adyenContext)
@@ -313,4 +319,24 @@ export function isGooglePayExpress(data) {
  */
 export function isPayPalExpress(data) {
     return data.paymentMethod?.type === 'paypal' && data.paymentMethod?.subtype === 'express'
+}
+
+/**
+ * Returns true when the SFCC order must be created before calling Adyen /payments, so an
+ * AUTHORISATION webhook can never arrive before the order exists.
+ * Gift cards are excluded because a partial payment order is only finalised once the remaining
+ * amount is covered. PayPal express is excluded because its request carries the net product
+ * amount, so the basket total is not final yet and a pre-created order would not match the
+ * authorised amount.
+ * @param {object} data - The payment state data from the client.
+ * @returns {boolean}
+ */
+export function shouldCreateOrderBeforePayment(data) {
+    if (data?.paymentMethod?.type === PAYMENT_METHOD_TYPES.GIFT_CARD) {
+        return false
+    }
+    if (data?.paymentMethod?.subtype !== 'express') {
+        return true
+    }
+    return isApplePayExpress(data) || isGooglePayExpress(data)
 }

--- a/packages/adyen-salesforce-pwa/lib/api/helpers/tests/orderHelper.test.js
+++ b/packages/adyen-salesforce-pwa/lib/api/helpers/tests/orderHelper.test.js
@@ -235,6 +235,79 @@ describe('orderHelper', () => {
             expect(result).toBe('current-basket-456')
         })
 
+        it('should fail the order without deleting or reopening baskets when reopenBasket is false', async () => {
+            const mockOrder = {
+                orderNo: 'order123',
+                customerInfo: {customerId: 'customer-abc'}
+            }
+            mockGetOrder.mockResolvedValue(mockOrder)
+            mockUpdateOrderStatus.mockResolvedValue({})
+            getCustomerBaskets.mockResolvedValue({baskets: [{basketId: 'basket-1'}]})
+            const mockDeleteBasket = jest.fn()
+            createShopperBasketsClient.mockReturnValue({deleteBasket: mockDeleteBasket})
+
+            const result = await failOrderAndReopenBasket(mockAdyenContext, 'order123', {
+                reopenBasket: false
+            })
+
+            expect(mockDeleteBasket).not.toHaveBeenCalled()
+            expect(mockUpdateOrderStatus).toHaveBeenCalledWith(
+                'order123',
+                ORDER.ORDER_STATUS_FAILED
+            )
+            expect(getBasket).not.toHaveBeenCalled()
+            expect(result).toBeNull()
+        })
+
+        it('should clear the shipping address on the reopened basket when removeShippingAddress is true', async () => {
+            const mockOrder = {
+                orderNo: 'order123',
+                customerInfo: {customerId: 'customer-abc'}
+            }
+            mockGetOrder.mockResolvedValue(mockOrder)
+            mockUpdateOrderStatus.mockResolvedValue({
+                headers: {
+                    get: jest.fn().mockReturnValue('/baskets/new-basket-123')
+                }
+            })
+            const mockRemoveShippingAddress = jest.fn().mockResolvedValue({})
+            BasketService.mockImplementation(() => ({
+                update: jest.fn().mockResolvedValue({}),
+                removeAllPaymentInstruments: jest.fn().mockResolvedValue({}),
+                removeShippingAddress: mockRemoveShippingAddress
+            }))
+
+            const result = await failOrderAndReopenBasket(mockAdyenContext, 'order123', {
+                removeShippingAddress: true
+            })
+
+            expect(mockRemoveShippingAddress).toHaveBeenCalled()
+            expect(result).toBe('new-basket-123')
+        })
+
+        it('should not clear the shipping address by default', async () => {
+            const mockOrder = {
+                orderNo: 'order123',
+                customerInfo: {customerId: 'customer-abc'}
+            }
+            mockGetOrder.mockResolvedValue(mockOrder)
+            mockUpdateOrderStatus.mockResolvedValue({
+                headers: {
+                    get: jest.fn().mockReturnValue('/baskets/new-basket-123')
+                }
+            })
+            const mockRemoveShippingAddress = jest.fn().mockResolvedValue({})
+            BasketService.mockImplementation(() => ({
+                update: jest.fn().mockResolvedValue({}),
+                removeAllPaymentInstruments: jest.fn().mockResolvedValue({}),
+                removeShippingAddress: mockRemoveShippingAddress
+            }))
+
+            await failOrderAndReopenBasket(mockAdyenContext, 'order123')
+
+            expect(mockRemoveShippingAddress).not.toHaveBeenCalled()
+        })
+
         it('should handle basket cleanup errors', async () => {
             const mockOrder = {
                 orderNo: 'order123',

--- a/packages/adyen-salesforce-pwa/lib/api/helpers/tests/paymentsHelper.test.js
+++ b/packages/adyen-salesforce-pwa/lib/api/helpers/tests/paymentsHelper.test.js
@@ -4,6 +4,7 @@ import {
     createPaymentRequestObject,
     revertCheckoutState,
     revertCheckoutStateForExpress,
+    shouldCreateOrderBeforePayment,
     validateBasketPayments,
     isApplePayExpress,
     isGooglePayExpress,
@@ -326,13 +327,26 @@ describe('paymentsHelper', () => {
             ).rejects.toThrow('Currency mismatch between payment and basket')
         })
 
-        it('should return early for express payments without throwing', async () => {
+        it('should return early for paypal express payments without throwing', async () => {
             const amount = {value: 5000}
-            const paymentMethod = {type: 'applepay', subtype: 'express'}
+            const paymentMethod = {type: 'paypal', subtype: 'express'}
             await expect(
                 validateBasketPayments(mockAdyenContext, amount, paymentMethod)
             ).resolves.toBeUndefined()
         })
+
+        it.each([['applepay'], ['googlepay']])(
+            'should validate %s express against the basket order total',
+            async (type) => {
+                const paymentMethod = {type, subtype: 'express'}
+                await expect(
+                    validateBasketPayments(mockAdyenContext, {value: 10000}, paymentMethod)
+                ).resolves.toBeUndefined()
+                await expect(
+                    validateBasketPayments(mockAdyenContext, {value: 5000}, paymentMethod)
+                ).rejects.toThrow(new AdyenError('amounts do not match', 409))
+            }
+        )
 
         it('should throw for invalid order data structure in partial payment', async () => {
             mockAdyenContext.basket.c_orderData = JSON.stringify({
@@ -777,7 +791,7 @@ describe('paymentsHelper', () => {
 
         it('should cleanup basket and remove shipping address', async () => {
             const mockAdyenContext = {
-                basket: {},
+                basket: {basketId: 'basket-1'},
                 basketService: {
                     update: jest.fn(),
                     removeAllPaymentInstruments: jest.fn(),
@@ -788,6 +802,45 @@ describe('paymentsHelper', () => {
             expect(mockAdyenContext.basketService.update).toHaveBeenCalled()
             expect(mockAdyenContext.basketService.removeAllPaymentInstruments).toHaveBeenCalled()
             expect(mockAdyenContext.basketService.removeShippingAddress).toHaveBeenCalled()
+        })
+
+        it('should do nothing when no basket is resolved', async () => {
+            const mockAdyenContext = {
+                basket: {},
+                basketService: {
+                    update: jest.fn(),
+                    removeAllPaymentInstruments: jest.fn(),
+                    removeShippingAddress: jest.fn()
+                }
+            }
+            await expect(
+                revertCheckoutStateForExpress(mockAdyenContext, 'test')
+            ).resolves.toBeUndefined()
+            expect(mockAdyenContext.basketService.update).not.toHaveBeenCalled()
+            expect(
+                mockAdyenContext.basketService.removeAllPaymentInstruments
+            ).not.toHaveBeenCalled()
+            expect(mockAdyenContext.basketService.removeShippingAddress).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('shouldCreateOrderBeforePayment', () => {
+        it.each([
+            [{type: 'scheme'}, true],
+            [{type: 'ideal'}, true],
+            [{type: 'applepay'}, true],
+            [{type: 'applepay', subtype: 'express'}, true],
+            [{type: 'googlepay', subtype: 'express'}, true],
+            [{type: 'paypal', subtype: 'express'}, false],
+            [{type: 'giftcard'}, false],
+            [{type: 'giftcard', subtype: 'express'}, false]
+        ])('should return %j -> %s', (paymentMethod, expected) => {
+            expect(shouldCreateOrderBeforePayment({paymentMethod})).toBe(expected)
+        })
+
+        it('should return true when no payment method is provided', () => {
+            expect(shouldCreateOrderBeforePayment({})).toBe(true)
+            expect(shouldCreateOrderBeforePayment(undefined)).toBe(true)
         })
     })
 

--- a/packages/adyen-salesforce-pwa/lib/components/googlepay/expressConfig.js
+++ b/packages/adyen-salesforce-pwa/lib/components/googlepay/expressConfig.js
@@ -288,7 +288,14 @@ export const getGooglePayExpressConfig = (props = {}) => {
                 if (!orderNo) {
                     throw new Error('Failed to generate order number')
                 }
-                setBasket({...currentBasket, c_orderNo: orderNo})
+                // In the PDP flow the order number belongs to the temporary basket, which is also
+                // what getActiveBasket() returns, so both references have to carry it.
+                if (isPdp) {
+                    temporaryBasket = {...temporaryBasket, c_orderNo: orderNo}
+                    setBasket(temporaryBasket)
+                } else {
+                    setBasket({...currentBasket, c_orderNo: orderNo})
+                }
 
                 const adyenPaymentService = new AdyenPaymentsService(
                     token,
@@ -331,7 +338,10 @@ export const getGooglePayExpressConfig = (props = {}) => {
                     props.site
                 )
                 const paymentsDetailsResponse =
-                    await adyenPaymentsDetailsService.submitPaymentsDetails(state.data)
+                    await adyenPaymentsDetailsService.submitPaymentsDetails(state.data, {
+                        orderNo: activeBasket?.c_orderNo,
+                        isTemporaryBasket: isPdp
+                    })
                 if (paymentsDetailsResponse?.isSuccessful) {
                     actions.resolve(paymentsDetailsResponse)
                     props.navigate(
@@ -345,7 +355,10 @@ export const getGooglePayExpressConfig = (props = {}) => {
                         activeBasket?.basketId,
                         props.site
                     )
-                    await paymentCancelExpressService.paymentCancelExpress()
+                    await paymentCancelExpressService.paymentCancelExpress({
+                        orderNo: activeBasket?.c_orderNo,
+                        isTemporaryBasket: isPdp
+                    })
                     if (props.onPaymentCancel) {
                         props.onPaymentCancel()
                     }
@@ -362,7 +375,10 @@ export const getGooglePayExpressConfig = (props = {}) => {
                         activeBasket?.basketId,
                         props.site
                     )
-                    await paymentCancelExpressService.paymentCancelExpress()
+                    await paymentCancelExpressService.paymentCancelExpress({
+                        orderNo: activeBasket?.c_orderNo,
+                        isTemporaryBasket: isPdp
+                    })
                 } catch (cancelErr) {
                     // Silently ignore cancellation errors
                 }
@@ -427,7 +443,10 @@ export const onErrorHandler = async (error, component, props) => {
                 basket?.basketId,
                 props.site
             )
-            await paymentCancelExpressService.paymentCancelExpress()
+            await paymentCancelExpressService.paymentCancelExpress({
+                orderNo: basket?.c_orderNo,
+                isTemporaryBasket: props.type === 'pdp'
+            })
         }
         if (props.onPaymentCancel) {
             props.onPaymentCancel()

--- a/packages/adyen-salesforce-pwa/lib/components/helpers/applePayExpress.utils.js
+++ b/packages/adyen-salesforce-pwa/lib/components/helpers/applePayExpress.utils.js
@@ -333,6 +333,8 @@ export const getAppleButtonConfig = (props = {}) => {
  * @param {string} props.customerId - Customer ID
  * @param {object} props.site - Site configuration
  * @param {Function} props.navigate - Navigation function
+ * @param {boolean} [props.isExpressPdp] - True for the PDP express flow, where the order was
+ * created from a temporary basket and the shopper's real cart must not be reopened
  * @returns {Promise<object>} Object indicating cancellation status
  */
 export const onErrorHandler = async (error, component, props) => {
@@ -345,7 +347,10 @@ export const onErrorHandler = async (error, component, props) => {
                 basket?.basketId,
                 props.site
             )
-            await paymentCancelExpressService.paymentCancelExpress()
+            await paymentCancelExpressService.paymentCancelExpress({
+                orderNo: basket?.c_orderNo,
+                isTemporaryBasket: props.isExpressPdp === true
+            })
         }
         props.navigate(`/checkout?error=true`)
         return {cancelled: true}

--- a/packages/adyen-salesforce-pwa/lib/components/tests/applePayExpress.utils.test.js
+++ b/packages/adyen-salesforce-pwa/lib/components/tests/applePayExpress.utils.test.js
@@ -929,7 +929,7 @@ describe('onErrorHandler', () => {
             customerId: 'customer-123',
             site: {id: 'RefArch'},
             navigate: jest.fn(),
-            getBasket: () => ({basketId: 'basket-456'})
+            getBasket: () => ({basketId: 'basket-456', c_orderNo: 'ORDER-001'})
         }
 
         const result = await onErrorHandler(new Error('Payment error'), {}, props)
@@ -940,9 +940,35 @@ describe('onErrorHandler', () => {
             'basket-456',
             {id: 'RefArch'}
         )
-        expect(mockPaymentCancelExpress).toHaveBeenCalled()
+        expect(mockPaymentCancelExpress).toHaveBeenCalledWith({
+            orderNo: 'ORDER-001',
+            isTemporaryBasket: false
+        })
         expect(props.navigate).toHaveBeenCalledWith('/checkout?error=true')
         expect(result).toEqual({cancelled: true})
+    })
+
+    it('should flag the basket as temporary for the pdp express flow', async () => {
+        const mockPaymentCancelExpress = jest.fn().mockResolvedValue({})
+        PaymentCancelExpressService.mockImplementation(() => ({
+            paymentCancelExpress: mockPaymentCancelExpress
+        }))
+
+        const props = {
+            token: 'test-token',
+            customerId: 'customer-123',
+            site: {id: 'RefArch'},
+            isExpressPdp: true,
+            navigate: jest.fn(),
+            getBasket: () => ({basketId: 'temp-basket-1', c_orderNo: 'ORDER-PDP'})
+        }
+
+        await onErrorHandler(new Error('Payment error'), {}, props)
+
+        expect(mockPaymentCancelExpress).toHaveBeenCalledWith({
+            orderNo: 'ORDER-PDP',
+            isTemporaryBasket: true
+        })
     })
 
     it('should handle cancellation errors gracefully', async () => {

--- a/packages/adyen-salesforce-pwa/lib/components/tests/googlepay-expressConfig.test.js
+++ b/packages/adyen-salesforce-pwa/lib/components/tests/googlepay-expressConfig.test.js
@@ -433,15 +433,106 @@ describe('getGooglePayExpressConfig', () => {
             expect(actions.resolve).toHaveBeenCalled()
         })
 
+        it('passes the pre-created order number from the cart flow to the details call', async () => {
+            const mockSubmitDetails = jest.fn().mockResolvedValue({
+                isSuccessful: true,
+                merchantReference: 'ORDER-001'
+            })
+            AdyenPaymentsDetailsService.mockImplementation(() => ({
+                submitPaymentsDetails: mockSubmitDetails
+            }))
+            AdyenPaymentsService.mockImplementation(() => ({
+                submitPayment: jest.fn().mockResolvedValue({action: {type: 'threeDS2'}})
+            }))
+            AdyenOrderNumberService.mockImplementation(() => ({
+                fetchOrderNumber: jest.fn().mockResolvedValue({orderNo: 'ORDER-001'})
+            }))
+            const config = getGooglePayExpressConfig(defaultProps)
+            await config.onSubmit(
+                {data: {}},
+                {handleAction: jest.fn()},
+                {resolve: jest.fn(), reject: jest.fn()}
+            )
+            await config.onAdditionalDetails(
+                {data: {details: {}}},
+                {},
+                {resolve: jest.fn(), reject: jest.fn()}
+            )
+
+            expect(mockSubmitDetails).toHaveBeenCalledWith(
+                {details: {}},
+                {orderNo: 'ORDER-001', isTemporaryBasket: false}
+            )
+        })
+
+        it('passes the temporary basket order number to the details call in the pdp flow', async () => {
+            const mockSubmitDetails = jest.fn().mockResolvedValue({
+                isSuccessful: true,
+                merchantReference: 'ORDER-PDP'
+            })
+            AdyenPaymentsDetailsService.mockImplementation(() => ({
+                submitPaymentsDetails: mockSubmitDetails
+            }))
+            AdyenPaymentsService.mockImplementation(() => ({
+                submitPayment: jest.fn().mockResolvedValue({action: {type: 'threeDS2'}})
+            }))
+            AdyenOrderNumberService.mockImplementation(() => ({
+                fetchOrderNumber: jest.fn().mockResolvedValue({orderNo: 'ORDER-PDP'})
+            }))
+            AdyenTemporaryBasketService.mockImplementation(() => ({
+                createTemporaryBasket: jest.fn().mockResolvedValue({
+                    basketId: 'temp-basket-1',
+                    orderTotal: 50,
+                    currency: 'USD',
+                    customerInfo: {customerId: 'customer-123'}
+                })
+            }))
+            const config = getGooglePayExpressConfig({
+                ...defaultProps,
+                type: 'pdp',
+                product: {id: 'prod-1', quantity: 1}
+            })
+            await config.onClick(jest.fn(), jest.fn())
+            await config.onSubmit(
+                {data: {}},
+                {handleAction: jest.fn()},
+                {resolve: jest.fn(), reject: jest.fn()}
+            )
+            await config.onAdditionalDetails(
+                {data: {details: {}}},
+                {},
+                {resolve: jest.fn(), reject: jest.fn()}
+            )
+
+            expect(AdyenPaymentsDetailsService).toHaveBeenLastCalledWith(
+                'test-token',
+                'customer-123',
+                'temp-basket-1',
+                {id: 'RefArch'}
+            )
+            expect(mockSubmitDetails).toHaveBeenCalledWith(
+                {details: {}},
+                {orderNo: 'ORDER-PDP', isTemporaryBasket: true}
+            )
+        })
+
         it('rejects and does not navigate when payment is not successful', async () => {
             AdyenPaymentsDetailsService.mockImplementation(() => ({
                 submitPaymentsDetails: jest.fn().mockResolvedValue({isSuccessful: false})
+            }))
+            const mockPaymentCancelExpress = jest.fn().mockResolvedValue({})
+            PaymentCancelExpressService.mockImplementation(() => ({
+                paymentCancelExpress: mockPaymentCancelExpress
             }))
             const navigate = jest.fn()
             const config = getGooglePayExpressConfig({...defaultProps, navigate})
             const actions = {resolve: jest.fn(), reject: jest.fn()}
             await config.onAdditionalDetails({data: {}}, {}, actions)
 
+            expect(mockPaymentCancelExpress).toHaveBeenCalledWith({
+                orderNo: undefined,
+                isTemporaryBasket: false
+            })
             expect(navigate).not.toHaveBeenCalled()
             expect(actions.reject).toHaveBeenCalled()
             expect(actions.resolve).not.toHaveBeenCalled()
@@ -635,7 +726,7 @@ describe('onErrorHandler', () => {
             customerId: 'customer-123',
             site: {id: 'RefArch'},
             navigate,
-            getBasket: () => ({basketId: 'basket-456'})
+            getBasket: () => ({basketId: 'basket-456', c_orderNo: 'ORDER-001'})
         }
         const result = await onErrorHandler(new Error('Payment error'), {}, props)
 
@@ -645,9 +736,33 @@ describe('onErrorHandler', () => {
             'basket-456',
             {id: 'RefArch'}
         )
-        expect(mockPaymentCancelExpress).toHaveBeenCalled()
+        expect(mockPaymentCancelExpress).toHaveBeenCalledWith({
+            orderNo: 'ORDER-001',
+            isTemporaryBasket: false
+        })
         expect(navigate).toHaveBeenCalledWith('/checkout?error=true')
         expect(result).toEqual({cancelled: true})
+    })
+
+    it('flags the basket as temporary for the pdp flow', async () => {
+        const mockPaymentCancelExpress = jest.fn().mockResolvedValue({})
+        PaymentCancelExpressService.mockImplementation(() => ({
+            paymentCancelExpress: mockPaymentCancelExpress
+        }))
+        const props = {
+            token: 'test-token',
+            customerId: 'customer-123',
+            site: {id: 'RefArch'},
+            type: 'pdp',
+            navigate: jest.fn(),
+            getBasket: () => ({basketId: 'temp-basket-1', c_orderNo: 'ORDER-PDP'})
+        }
+        await onErrorHandler(new Error('Payment error'), {}, props)
+
+        expect(mockPaymentCancelExpress).toHaveBeenCalledWith({
+            orderNo: 'ORDER-PDP',
+            isTemporaryBasket: true
+        })
     })
 
     it('cancels express payment and calls onPaymentCancel when provided', async () => {

--- a/packages/adyen-salesforce-pwa/lib/services/payment-cancel-express.js
+++ b/packages/adyen-salesforce-pwa/lib/services/payment-cancel-express.js
@@ -8,10 +8,18 @@ export class PaymentCancelExpressService {
         this.apiClient = new ApiClient(this.baseUrl, token, customerId, basketId, site)
     }
 
-    async paymentCancelExpress() {
+    /**
+     * Cancels an express payment.
+     * @param {object} [options] - Cancellation options.
+     * @param {string} [options.orderNo] - Order number when the SFCC order was already created.
+     * @param {boolean} [options.isTemporaryBasket] - True for the PDP express flow, so the
+     * shopper's real cart is not reopened over the temporary basket.
+     * @returns {Promise<object>} The cancellation response, including newBasketId when reopened.
+     */
+    async paymentCancelExpress({orderNo, isTemporaryBasket} = {}) {
         const res = await this.apiClient.post({
             path: '/cancel/express',
-            body: JSON.stringify({})
+            body: JSON.stringify({orderNo, isTemporaryBasket})
         })
         if (res.status >= 300) {
             const errorData = await res

--- a/packages/adyen-salesforce-pwa/lib/services/payments-details.js
+++ b/packages/adyen-salesforce-pwa/lib/services/payments-details.js
@@ -8,10 +8,21 @@ export class AdyenPaymentsDetailsService {
         this.apiClient = new ApiClient(this.baseUrl, token, customerId, basketId, site)
     }
 
-    async submitPaymentsDetails(data) {
+    /**
+     * Submits additional payment details (3DS, redirect result) to Adyen.
+     * @param {object} data - The Adyen state data for the details call.
+     * @param {object} [options] - Order context for express flows.
+     * @param {string} [options.orderNo] - Order number when the SFCC order was already created.
+     * @param {boolean} [options.isTemporaryBasket] - True for the PDP express flow, so the
+     * shopper's real cart is not reopened over the temporary basket on failure.
+     * @returns {Promise<object>} The checkout response.
+     */
+    async submitPaymentsDetails(data, {orderNo, isTemporaryBasket} = {}) {
         const res = await this.apiClient.post({
             body: JSON.stringify({
-                data
+                data,
+                orderNo,
+                isTemporaryBasket
             })
         })
         if (res.status >= 300) {

--- a/packages/adyen-salesforce-pwa/lib/services/tests/payment-cancel-express.test.js
+++ b/packages/adyen-salesforce-pwa/lib/services/tests/payment-cancel-express.test.js
@@ -50,6 +50,24 @@ describe('PaymentCancelExpressService', () => {
             expect(result).toEqual(mockPayload)
         })
 
+        it('should include the order context in the request body', async () => {
+            mockPost.mockResolvedValue({
+                status: 200,
+                json: jest.fn().mockResolvedValue({newBasketId: 'basket-new'})
+            })
+
+            const result = await service.paymentCancelExpress({
+                orderNo: 'order-1',
+                isTemporaryBasket: true
+            })
+
+            expect(mockPost).toHaveBeenCalledWith({
+                path: '/cancel/express',
+                body: JSON.stringify({orderNo: 'order-1', isTemporaryBasket: true})
+            })
+            expect(result).toEqual({newBasketId: 'basket-new'})
+        })
+
         it('should throw an error with server message when status >= 300', async () => {
             mockPost.mockResolvedValue({
                 status: 400,

--- a/packages/adyen-salesforce-pwa/lib/services/tests/payments-details.test.js
+++ b/packages/adyen-salesforce-pwa/lib/services/tests/payments-details.test.js
@@ -59,6 +59,28 @@ describe('AdyenPaymentsDetailsService', () => {
         expect(paymentDetailsResult).toEqual(mockResponse)
     })
 
+    it('should include the order context in the request body when provided', async () => {
+        paymentsDetailsService.apiClient.post.mockResolvedValueOnce(
+            Promise.resolve({
+                json: () => Promise.resolve({isSuccessful: true}),
+                status: 200
+            })
+        )
+
+        await paymentsDetailsService.submitPaymentsDetails(mockData, {
+            orderNo: 'order-1',
+            isTemporaryBasket: true
+        })
+
+        expect(paymentsDetailsService.apiClient.post).toHaveBeenCalledWith({
+            body: JSON.stringify({
+                data: mockData,
+                orderNo: 'order-1',
+                isTemporaryBasket: true
+            })
+        })
+    })
+
     it('should throw an error when submitPaymentsDetails gets a status >= 300', async () => {
         const mockFetchPromise = Promise.resolve({
             status: 400,


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
Create order before making 
- What existing problem does this pull request solve?
Race condition with auth webhook arriving before creating the order

## Tested scenarios
Description of tested scenarios:
- Express payments (Apple Pay / Google Pay)

**Fixed issue**:  SFI-1702
