### PR TITLE
[SFI-1696] Prevent Google Pay from deleting reopened baskets

### DIFF
--- a/packages/adyen-salesforce-pwa/lib/api/helpers/orderHelper.js
+++ b/packages/adyen-salesforce-pwa/lib/api/helpers/orderHelper.js
@@ -59,6 +59,33 @@ export function createShopperOrderClient(authorization, siteId) {
     })
 }
 
+export async function resolveReopenedBasket({
+    authorization,
+    customerId,
+    siteId,
+    basketIdFromLocation
+}) {
+    if (basketIdFromLocation) {
+        try {
+            return await getBasket(authorization, basketIdFromLocation, customerId, siteId)
+        } catch (err) {
+            Logger.info(
+                'resolveReopenedBasket',
+                `Location basket ${basketIdFromLocation} not usable (${err.statusCode}: ${err.message}), falling back`
+            )
+        }
+    }
+    try {
+        return await getCurrentBasketForAuthorizedShopper(authorization, customerId, siteId)
+    } catch (err) {
+        Logger.error(
+            'resolveReopenedBasket',
+            `Could not resolve reopened basket: ${err.statusCode}: ${err.message}`
+        )
+    }
+    return null
+}
+
 /**
  * Fails an SFCC order and, by default, triggers the reopening of the associated basket.
  * It validates that the order belongs to the customer, deletes all existing shopper baskets,
@@ -99,19 +126,23 @@ export async function failOrderAndReopenBasket(adyenContext, orderNo, options = 
                 'failOrderAndReopenBasket',
                 `Order ${orderNo} is ${order.status}; skipping fail and reopen`
             )
-            try {
-                const currentBasket = await getCurrentBasketForAuthorizedShopper(
-                    authorization,
-                    customerId,
-                    siteId
+            const currentBasket = await resolveReopenedBasket({
+                authorization,
+                customerId,
+                siteId,
+                basketIdFromLocation: null
+            })
+            if (!currentBasket) {
+                return null
+            }
+            if (currentBasket.c_orderNo !== orderNo) {
+                Logger.info(
+                    'failOrderAndReopenBasket',
+                    `Current basket does not reference order ${orderNo}; skipping cleanup`
                 )
-                if (currentBasket?.c_orderNo !== orderNo) {
-                    Logger.info(
-                        'failOrderAndReopenBasket',
-                        `Current basket does not reference order ${orderNo}; skipping cleanup`
-                    )
-                    return null
-                }
+                return null
+            }
+            try {
                 const tempContext = {...adyenContext, basket: currentBasket}
                 const tempRes = {locals: {adyen: tempContext}}
                 tempContext.basketService = new BasketService(tempContext, tempRes)
@@ -157,20 +188,30 @@ export async function failOrderAndReopenBasket(adyenContext, orderNo, options = 
     const match = location?.match(/baskets\/([^?/]+)/)
     let newBasketId = match ? match[1] : null
 
-    try {
-        const newBasket = newBasketId
-            ? await getBasket(authorization, newBasketId, customerId, siteId)
-            : await getCurrentBasketForAuthorizedShopper(authorization, customerId, siteId)
-        newBasketId = newBasket?.basketId
-        const tempContext = {...adyenContext, basket: newBasket}
-        const tempRes = {locals: {adyen: tempContext}}
-        tempContext.basketService = new BasketService(tempContext, tempRes)
-        await cleanupReopenedBasket(tempContext, 'failOrderAndReopenBasket')
-        if (removeShippingAddress) {
-            await tempContext.basketService.removeShippingAddress()
+    const reopenedBasket = await resolveReopenedBasket({
+        authorization,
+        customerId,
+        siteId,
+        basketIdFromLocation: newBasketId
+    })
+    if (reopenedBasket?.basketId) {
+        newBasketId = reopenedBasket.basketId
+    }
+    if (reopenedBasket) {
+        try {
+            const tempContext = {...adyenContext, basket: reopenedBasket}
+            const tempRes = {locals: {adyen: tempContext}}
+            tempContext.basketService = new BasketService(tempContext, tempRes)
+            await cleanupReopenedBasket(tempContext, 'failOrderAndReopenBasket')
+            if (removeShippingAddress) {
+                await tempContext.basketService.removeShippingAddress()
+            }
+        } catch (err) {
+            Logger.error(
+                'failOrderAndReopenBasket',
+                `Failed to clean up new basket: ${err.message}`
+            )
         }
-    } catch (err) {
-        Logger.error('failOrderAndReopenBasket', `Failed to clean up new basket: ${err.message}`)
     }
     Logger.info('failOrderAndReopenBasket', 'success')
     return newBasketId

--- a/packages/adyen-salesforce-pwa/lib/api/helpers/orderHelper.js
+++ b/packages/adyen-salesforce-pwa/lib/api/helpers/orderHelper.js
@@ -71,7 +71,7 @@ export async function resolveReopenedBasket({
         } catch (err) {
             Logger.info(
                 'resolveReopenedBasket',
-                `Location basket ${basketIdFromLocation} not usable (${err.statusCode}: ${err.message}), falling back`
+                `Location basket ${basketIdFromLocation} not usable (${err?.statusCode ?? 'unknown'}: ${err?.message ?? String(err)}), falling back`
             )
         }
     }
@@ -80,7 +80,7 @@ export async function resolveReopenedBasket({
     } catch (err) {
         Logger.error(
             'resolveReopenedBasket',
-            `Could not resolve reopened basket: ${err.statusCode}: ${err.message}`
+            `Could not resolve reopened basket: ${err?.statusCode ?? 'unknown'}: ${err?.message ?? String(err)}`
         )
     }
     return null

--- a/packages/adyen-salesforce-pwa/lib/api/helpers/tests/orderHelper.test.js
+++ b/packages/adyen-salesforce-pwa/lib/api/helpers/tests/orderHelper.test.js
@@ -184,7 +184,73 @@ describe('orderHelper', () => {
                 'order123',
                 ORDER.ORDER_STATUS_FAILED_REOPEN
             )
+            expect(getBasket).toHaveBeenCalledTimes(1)
+            expect(getCurrentBasketForAuthorizedShopper).not.toHaveBeenCalled()
             expect(result).toBe('new-basket-123')
+        })
+
+        it('should fall back to the current basket when the Location basket is unavailable', async () => {
+            const mockOrder = {
+                orderNo: 'order123',
+                status: ORDER.ORDER_STATUS_CREATED,
+                customerInfo: {customerId: 'customer-abc'}
+            }
+            mockGetOrder.mockResolvedValue(mockOrder)
+            mockUpdateOrderStatus.mockResolvedValue({
+                headers: {
+                    get: jest.fn().mockReturnValue('/baskets/location-basket-123')
+                }
+            })
+            getBasket.mockRejectedValue(
+                Object.assign(new Error('Basket not found'), {statusCode: 404})
+            )
+            getCurrentBasketForAuthorizedShopper.mockResolvedValue({
+                basketId: 'current-basket-456'
+            })
+
+            const result = await failOrderAndReopenBasket(mockAdyenContext, 'order123')
+
+            expect(getBasket).toHaveBeenCalledTimes(1)
+            expect(getCurrentBasketForAuthorizedShopper).toHaveBeenCalledTimes(1)
+            expect(getCurrentBasketForAuthorizedShopper).toHaveBeenCalledWith(
+                'auth',
+                'customer-abc',
+                'RefArch'
+            )
+            expect(mockBasketUpdate).toHaveBeenCalledWith(expect.objectContaining({c_orderNo: ''}))
+            expect(mockRemoveAllPaymentInstruments).toHaveBeenCalled()
+            expect(result).toBe('current-basket-456')
+        })
+
+        it('should preserve the Location basket ID when no reopened basket can be resolved', async () => {
+            mockGetOrder.mockResolvedValue({
+                orderNo: 'order123',
+                status: ORDER.ORDER_STATUS_CREATED,
+                customerInfo: {customerId: 'customer-abc'}
+            })
+            mockUpdateOrderStatus.mockResolvedValue({
+                headers: {
+                    get: jest.fn().mockReturnValue('/baskets/location-basket-123')
+                }
+            })
+            getBasket.mockRejectedValue(
+                Object.assign(new Error('Basket not found'), {statusCode: 404})
+            )
+            getCurrentBasketForAuthorizedShopper.mockRejectedValue(
+                Object.assign(new Error('No current basket'), {statusCode: 404})
+            )
+
+            const result = await failOrderAndReopenBasket(mockAdyenContext, 'order123')
+
+            expect(getBasket).toHaveBeenCalledTimes(1)
+            expect(getCurrentBasketForAuthorizedShopper).toHaveBeenCalledTimes(1)
+            expect(mockBasketUpdate).not.toHaveBeenCalled()
+            expect(mockRemoveAllPaymentInstruments).not.toHaveBeenCalled()
+            expect(result).toBe('location-basket-123')
+            expect(Logger.error).toHaveBeenCalledWith(
+                'resolveReopenedBasket',
+                'Could not resolve reopened basket: 404: No current basket'
+            )
         })
 
         it('should throw AdyenError if order is not found', async () => {
@@ -382,7 +448,7 @@ describe('orderHelper', () => {
                     get: jest.fn().mockReturnValue('/baskets/new-basket-123')
                 }
             })
-            getBasket.mockRejectedValue(new Error('Basket fetch failed'))
+            mockBasketUpdate.mockRejectedValue(new Error('Basket cleanup failed'))
 
             const result = await failOrderAndReopenBasket(mockAdyenContext, 'order123')
 

--- a/packages/adyen-salesforce-pwa/lib/api/helpers/tests/orderHelper.test.js
+++ b/packages/adyen-salesforce-pwa/lib/api/helpers/tests/orderHelper.test.js
@@ -4,6 +4,7 @@ import {
     failOrderAndReopenBasket,
     getOrderUsingOrderNo,
     getOpenOrderForShopper,
+    resolveReopenedBasket,
     updateOrderPaymentInstrument
 } from '../orderHelper.js'
 import {ShopperOrders} from 'commerce-sdk-isomorphic'
@@ -127,6 +128,43 @@ describe('orderHelper', () => {
                 },
                 headers: {authorization: mockAuth}
             })
+        })
+    })
+
+    describe('resolveReopenedBasket', () => {
+        it('should fall back when the Location basket rejects without an error object', async () => {
+            getBasket.mockRejectedValue(null)
+            getCurrentBasketForAuthorizedShopper.mockResolvedValue({basketId: 'current-basket'})
+
+            const result = await resolveReopenedBasket({
+                authorization: 'auth',
+                customerId: 'customer-abc',
+                siteId: 'RefArch',
+                basketIdFromLocation: 'location-basket'
+            })
+
+            expect(result).toEqual({basketId: 'current-basket'})
+            expect(Logger.info).toHaveBeenCalledWith(
+                'resolveReopenedBasket',
+                'Location basket location-basket not usable (unknown: null), falling back'
+            )
+        })
+
+        it('should return null when current basket resolution rejects without an error object', async () => {
+            getCurrentBasketForAuthorizedShopper.mockRejectedValue(undefined)
+
+            const result = await resolveReopenedBasket({
+                authorization: 'auth',
+                customerId: 'customer-abc',
+                siteId: 'RefArch',
+                basketIdFromLocation: null
+            })
+
+            expect(result).toBeNull()
+            expect(Logger.error).toHaveBeenCalledWith(
+                'resolveReopenedBasket',
+                'Could not resolve reopened basket: unknown: undefined'
+            )
         })
     })
 

--- a/packages/adyen-salesforce-pwa/lib/components/helpers/baseConfig.js
+++ b/packages/adyen-salesforce-pwa/lib/components/helpers/baseConfig.js
@@ -1,6 +1,13 @@
 import {AdyenPaymentsService} from '../../services/payments'
 import {AdyenPaymentsDetailsService} from '../../services/payments-details'
-import {executeCallbacks, createThrottledErrorHandler} from '../../utils/executeCallbacks'
+import {
+    executeCallbacks,
+    createThrottledErrorHandler,
+    clearCancelHandled,
+    clearErrorNotificationThrottle,
+    hasCancelHandled,
+    markCancelHandled
+} from '../../utils/executeCallbacks'
 import {getCurrencyValueForApi} from '../../utils/parsers.mjs'
 import {PaymentCancelService} from '../../services/payment-cancel'
 import {ERROR_NOTIFICATION_KEYS} from '../../utils/constants.mjs'
@@ -43,6 +50,8 @@ export const baseConfig = (props) => {
 }
 
 export const onSubmit = async (state, component, actions, props) => {
+    clearCancelHandled(ERROR_NOTIFICATION_KEYS.CHECKOUT)
+    clearErrorNotificationThrottle(ERROR_NOTIFICATION_KEYS.CHECKOUT)
     try {
         if (!state.isValid) {
             throw new Error('invalid state')
@@ -92,16 +101,25 @@ export const onErrorHandler = async (error, component, props) => {
     try {
         let newBasketId = error?.newBasketId
         const basket = props.getBasket ? props.getBasket() : props.basket
-        if (!newBasketId) {
-            const paymentCancelService = new PaymentCancelService(
-                props.token,
-                props.customerId,
-                basket?.basketId,
-                props.site
-            )
-            const cancelResponse = await paymentCancelService.paymentCancel(props.orderNo)
-            if (cancelResponse?.newBasketId) {
-                newBasketId = cancelResponse.newBasketId
+        if (newBasketId) {
+            markCancelHandled(ERROR_NOTIFICATION_KEYS.CHECKOUT)
+        } else if (!hasCancelHandled(ERROR_NOTIFICATION_KEYS.CHECKOUT)) {
+            markCancelHandled(ERROR_NOTIFICATION_KEYS.CHECKOUT)
+            try {
+                const paymentCancelService = new PaymentCancelService(
+                    props.token,
+                    props.customerId,
+                    basket?.basketId,
+                    props.site
+                )
+                const cancelResponse = await paymentCancelService.paymentCancel(props.orderNo)
+                if (cancelResponse?.newBasketId) {
+                    newBasketId = cancelResponse.newBasketId
+                }
+            } catch (err) {
+                clearCancelHandled(ERROR_NOTIFICATION_KEYS.CHECKOUT)
+                clearErrorNotificationThrottle(ERROR_NOTIFICATION_KEYS.CHECKOUT)
+                throw err
             }
         }
         if (props.adyenOrder) {

--- a/packages/adyen-salesforce-pwa/lib/components/tests/baseConfig.test.js
+++ b/packages/adyen-salesforce-pwa/lib/components/tests/baseConfig.test.js
@@ -97,6 +97,7 @@ describe('onSubmit function', () => {
     let mockSubmitPayment
 
     beforeEach(() => {
+        __resetErrorNotificationThrottle()
         mockActions = {
             resolve: jest.fn(),
             reject: jest.fn()
@@ -105,6 +106,10 @@ describe('onSubmit function', () => {
         AdyenPaymentsService.mockImplementation(() => ({
             submitPayment: mockSubmitPayment
         }))
+    })
+
+    afterEach(() => {
+        __resetErrorNotificationThrottle()
     })
 
     it('calls reject for invalid state and returns undefined', async () => {
@@ -228,6 +233,56 @@ describe('onSubmit function', () => {
             {id: 'en-US'}
         )
     })
+
+    it('should allow cancellation again when a new payment attempt starts', async () => {
+        const props = {
+            token: 'testToken',
+            site: 'testSite',
+            customerId: 'testCustomer',
+            navigate: jest.fn(),
+            orderNo: '12345',
+            basket: {basketId: 'basket123'},
+            returnUrl: 'https://adyen.com'
+        }
+        const mockPaymentCancel = jest.fn().mockResolvedValue({})
+        PaymentCancelService.mockImplementation(() => ({
+            paymentCancel: mockPaymentCancel
+        }))
+        const paymentError = new Error('Payment failed')
+        paymentError.newBasketId = 'new-basket-456'
+
+        await onErrorHandler(paymentError, {}, props)
+        await onSubmit({data: {origin: 'https://adyen.com'}, isValid: true}, {}, mockActions, props)
+        await onErrorHandler(new Error('New attempt failed'), {}, props)
+
+        expect(mockPaymentCancel).toHaveBeenCalledTimes(1)
+        expect(mockPaymentCancel).toHaveBeenCalledWith('12345')
+    })
+
+    it('should notify errors immediately after a new payment attempt starts', async () => {
+        const props = {
+            token: 'testToken',
+            site: 'testSite',
+            customerId: 'testCustomer',
+            navigate: jest.fn(),
+            orderNo: '12345',
+            basket: {basketId: 'basket123', orderTotal: 100, currency: 'USD'},
+            returnUrl: 'https://adyen.com'
+        }
+        const mockPaymentCancel = jest.fn().mockResolvedValue({})
+        PaymentCancelService.mockImplementation(() => ({
+            paymentCancel: mockPaymentCancel
+        }))
+        const config = baseConfig(props)
+        const paymentError = new Error('Payment failed')
+        paymentError.newBasketId = 'new-basket-456'
+
+        await config.onError(paymentError, {})
+        await config.onSubmit({data: {origin: 'https://adyen.com'}, isValid: true}, {}, mockActions)
+        await config.onError(new Error('New attempt failed'), {})
+
+        expect(mockPaymentCancel).toHaveBeenCalledTimes(1)
+    })
 })
 
 describe('onAdditionalDetails function', () => {
@@ -323,10 +378,12 @@ describe('onErrorHandler', () => {
     let consoleErrorSpy
 
     beforeEach(() => {
+        __resetErrorNotificationThrottle()
         consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
     })
 
     afterEach(() => {
+        __resetErrorNotificationThrottle()
         consoleErrorSpy.mockRestore()
     })
 
@@ -450,6 +507,113 @@ describe('onErrorHandler', () => {
             '/checkout?error=true&newBasketId=already-created-basket'
         )
         expect(result).toEqual({cancelled: true})
+    })
+
+    it('should not cancel again after the server already reopened the basket', async () => {
+        const navigate = jest.fn()
+        const props = {
+            token: 'testToken',
+            site: 'testSite',
+            customerId: 'testCustomer',
+            navigate,
+            orderNo: '12345',
+            basket: {basketId: 'basket123'}
+        }
+        const mockPaymentCancel = jest.fn()
+        PaymentCancelService.mockImplementation(() => ({
+            paymentCancel: mockPaymentCancel
+        }))
+        const paymentError = new Error('Payment failed')
+        paymentError.newBasketId = 'new-basket-456'
+
+        await onErrorHandler(paymentError, {}, props)
+        await onErrorHandler(new Error('Google Pay closed'), {}, props)
+
+        expect(mockPaymentCancel).not.toHaveBeenCalled()
+        expect(navigate).toHaveBeenNthCalledWith(
+            1,
+            '/checkout?error=true&newBasketId=new-basket-456'
+        )
+        expect(navigate).toHaveBeenNthCalledWith(2, '/checkout?error=true')
+    })
+
+    it('should issue only one cancellation while duplicate errors are handled concurrently', async () => {
+        const props = {
+            token: 'testToken',
+            site: 'testSite',
+            customerId: 'testCustomer',
+            navigate: jest.fn(),
+            orderNo: '12345',
+            basket: {basketId: 'basket123'}
+        }
+        let resolveCancel
+        const pendingCancel = new Promise((resolve) => {
+            resolveCancel = resolve
+        })
+        const mockPaymentCancel = jest.fn().mockReturnValue(pendingCancel)
+        PaymentCancelService.mockImplementation(() => ({
+            paymentCancel: mockPaymentCancel
+        }))
+
+        const firstError = onErrorHandler(new Error('Payment failed'), {}, props)
+        const secondError = onErrorHandler(new Error('Google Pay closed'), {}, props)
+        resolveCancel({})
+        await Promise.all([firstError, secondError])
+
+        expect(mockPaymentCancel).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not retry cancellation when navigation fails after a successful cancel', async () => {
+        const navigationError = new Error('Navigation failed')
+        const navigate = jest.fn().mockImplementationOnce(() => {
+            throw navigationError
+        })
+        const props = {
+            token: 'testToken',
+            site: 'testSite',
+            customerId: 'testCustomer',
+            navigate,
+            orderNo: '12345',
+            basket: {basketId: 'basket123'}
+        }
+        const mockPaymentCancel = jest.fn().mockResolvedValue({})
+        PaymentCancelService.mockImplementation(() => ({
+            paymentCancel: mockPaymentCancel
+        }))
+
+        await onErrorHandler(new Error('Payment failed'), {}, props)
+        await onErrorHandler(new Error('Google Pay closed'), {}, props)
+
+        expect(mockPaymentCancel).toHaveBeenCalledTimes(1)
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            'Error during payment cancellation:',
+            navigationError
+        )
+    })
+
+    it('should allow an immediate retry when the cancellation request fails', async () => {
+        const props = {
+            token: 'testToken',
+            site: 'testSite',
+            customerId: 'testCustomer',
+            navigate: jest.fn(),
+            orderNo: '12345',
+            basket: {basketId: 'basket123', orderTotal: 100, currency: 'USD'}
+        }
+        const cancelError = new Error('Cancel failed')
+        const mockPaymentCancel = jest
+            .fn()
+            .mockRejectedValueOnce(cancelError)
+            .mockResolvedValueOnce({})
+        PaymentCancelService.mockImplementation(() => ({
+            paymentCancel: mockPaymentCancel
+        }))
+        const config = baseConfig(props)
+
+        await config.onError(new Error('Payment failed'), {})
+        await config.onPaymentFailed(new Error('Payment still failed'), {})
+
+        expect(mockPaymentCancel).toHaveBeenCalledTimes(2)
     })
 
     it('should handle cancellation errors gracefully', async () => {

--- a/packages/adyen-salesforce-pwa/lib/utils/executeCallbacks.js
+++ b/packages/adyen-salesforce-pwa/lib/utils/executeCallbacks.js
@@ -4,6 +4,12 @@
 // state would leak across shoppers' requests. All current call sites are browser-only
 // (Adyen Web SDK callbacks, React component event handlers).
 const errorNotificationTimestamps = new Map()
+const cancelHandledKeys = new Set()
+
+export const markCancelHandled = (key) => cancelHandledKeys.add(key)
+export const hasCancelHandled = (key) => cancelHandledKeys.has(key)
+export const clearCancelHandled = (key) => cancelHandledKeys.delete(key)
+export const clearErrorNotificationThrottle = (key) => errorNotificationTimestamps.delete(key)
 
 /**
  * Leading-edge throttle gate for error notifications.
@@ -30,6 +36,7 @@ export const shouldNotifyError = (key, windowMs = 300) => {
  */
 export const __resetErrorNotificationThrottle = () => {
     errorNotificationTimestamps.clear()
+    cancelHandledKeys.clear()
 }
 
 /**

--- a/packages/adyen-salesforce-pwa/lib/utils/tests/executeCallbacks.test.js
+++ b/packages/adyen-salesforce-pwa/lib/utils/tests/executeCallbacks.test.js
@@ -2,6 +2,9 @@ import {
     executeCallbacks,
     executeErrorCallbacks,
     shouldNotifyError,
+    markCancelHandled,
+    hasCancelHandled,
+    clearCancelHandled,
     __resetErrorNotificationThrottle,
     createThrottledErrorHandler
 } from '../executeCallbacks'
@@ -49,6 +52,30 @@ describe('shouldNotifyError', () => {
         __resetErrorNotificationThrottle()
 
         expect(shouldNotifyError('test-key')).toBe(true)
+    })
+})
+
+describe('cancel handled state', () => {
+    beforeEach(() => {
+        __resetErrorNotificationThrottle()
+    })
+
+    it('should mark and clear a handled cancellation by key', () => {
+        expect(hasCancelHandled('checkout')).toBe(false)
+
+        markCancelHandled('checkout')
+        expect(hasCancelHandled('checkout')).toBe(true)
+
+        clearCancelHandled('checkout')
+        expect(hasCancelHandled('checkout')).toBe(false)
+    })
+
+    it('should clear handled cancellations when shared test state is reset', () => {
+        markCancelHandled('checkout')
+
+        __resetErrorNotificationThrottle()
+
+        expect(hasCancelHandled('checkout')).toBe(false)
     })
 })
 


### PR DESCRIPTION
## Summary
- Prevent a follow-up Google Pay popup-close error from issuing a second destructive payment cancellation after the server has already reopened the checkout basket.
- Resolve reopened baskets with a single Location-to-current-basket fallback, preserve a usable basket ID when resolution fails, and clean stale order/payment state when resolution succeeds.
- Track cancellation handling atomically per checkout attempt, reset state for new attempts, and allow immediate retries only when the cancellation request itself fails.
- Affects only the published `packages/adyen-salesforce-pwa` package; no cartridge, metadata, E2E, or retail-app production logic changed.

## Tested scenarios
- Added and updated unit coverage in `orderHelper.test.js`, `baseConfig.test.js`, and `executeCallbacks.test.js` for basket fallback, unresolved baskets, cleanup failures, duplicate and concurrent errors, new-attempt reset, navigation failure, and cancellation retry behavior.
- Package lint passed; package coverage passed with 104 suites and 1,532 tests (97.58% statements, 92.18% branches, 98.41% functions, 97.9% lines).
- Retail app lint passed; cartridge coverage passed with 26 suites and 119 tests (99.81% statements, 91.62% branches, 100% functions, 99.81% lines).
- Sandbox E2E remains required for refused Google Pay checkout followed by popup close, for both guest and registered shoppers, verifying one basket recreation, preserved cleaned basket, and a fresh order number on retry.

**Fixed issue**: SFI-1696